### PR TITLE
Parallelize scene publication and renderer packet preparation

### DIFF
--- a/Runtime/Containers/Octree.h
+++ b/Runtime/Containers/Octree.h
@@ -101,7 +101,8 @@ namespace Sailor
 	public:
 
 		// Constructors & Destructor
-		TOctree(glm::ivec3 center = glm::ivec3(0, 0, 0), uint32_t size = 16536u, uint32_t minSize = 4) : m_map(size)
+		TOctree(glm::ivec3 center = glm::ivec3(0, 0, 0), uint32_t size = 16536u, uint32_t minSize = 4,
+			size_t initialCapacity = 64u) : m_map(initialCapacity)
 		{
 			m_minSize = minSize;
 			m_root = Memory::New<TNode>(m_allocator);

--- a/Runtime/ECS/LandscapeScene.cpp
+++ b/Runtime/ECS/LandscapeScene.cpp
@@ -185,14 +185,14 @@ void LandscapeECS::PublishSceneVersion()
 		}
 
 		auto rebuildSpatialTree =
-			[this](EMobilityType mobility, bool bHasEntries, TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& tree)
+			[this](EMobilityType mobility, bool bHasEntries, TSharedPtr<RHI::RHISceneSpatialIndex>& tree)
 		{
 			if (!bHasEntries)
 			{
 				tree.Clear();
 				return;
 			}
-			tree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(glm::ivec3(0, 0, 0), 16536 * 16, 4);
+			tree = TSharedPtr<RHI::RHISceneSpatialIndex>::Make(glm::ivec3(0, 0, 0), 16536 * 16, 4);
 			auto appendSpatialEntry = [this, &tree](const RHI::RHISceneProxyResourcePtr& resource,
 										  const glm::ivec3& center,
 										  const glm::ivec3& extents)

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -338,72 +338,61 @@ void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
 			(spatialChangeMask & StationarySpatialChange) != 0u;
 		const bool bRebuildDynamic = !m_publishedSceneVersion ||
 			(spatialChangeMask & DynamicSpatialChange) != 0u;
-		if (bRebuildStatic)
-		{
-			version->m_staticOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
-				glm::ivec3(0, 0, 0), 16536 * 16, 4);
-		}
-		if (!bRebuildStatic)
-		{
-			version->m_staticOctree = m_publishedSceneVersion->m_staticOctree;
-		}
-		if (bRebuildStationary)
-		{
-			version->m_stationaryOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
-				glm::ivec3(0, 0, 0), 16536 * 16, 4);
-		}
-		if (!bRebuildStationary)
-		{
-			version->m_stationaryOctree = m_publishedSceneVersion->m_stationaryOctree;
-		}
-		if (bRebuildDynamic)
-		{
-			version->m_dynamicOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
-				glm::ivec3(0, 0, 0), 16536 * 16, 4);
-		}
-		if (!bRebuildDynamic)
-		{
-			version->m_dynamicOctree = m_publishedSceneVersion->m_dynamicOctree;
-		}
-
-		auto rebuildSpatialRoot = [&](const TSharedPtr<TVector<RHI::RenderInstanceHandle>>& handles,
-			const TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& octree)
+		auto rebuildSpatialRoot = [&](const TSharedPtr<TVector<RHI::RenderInstanceHandle>>& handles)
 			{
 				SAILOR_PROFILE_SCOPE("Rebuild scene spatial root");
-				if (!handles || !octree)
-				{
-					return;
-				}
-				for (const auto& handle : *handles)
-				{
-					const RHI::RHISceneInstanceRecord* record = nullptr;
-					if (!version->m_sceneVersion->Resolve(handle, record) || !record)
+				const size_t numHandles = handles ? handles->Num() : 0u;
+				const auto* scheduler = App::GetSubmodule<Tasks::Scheduler>();
+				const size_t numWorkers = scheduler ? (std::max)(size_t(1u), size_t(scheduler->GetNumWorkerThreads())) : 1u;
+				const size_t numPartitions = (std::max)(size_t(1u),
+					(std::min)(numWorkers, (numHandles + 511u) / 512u));
+				const size_t partitionSize = (numHandles + numPartitions - 1u) / numPartitions;
+				auto index = TSharedPtr<RHI::RHISceneSpatialIndex>::Make(
+					glm::ivec3(0), 16536 * 16, 4, numPartitions, (std::max)(size_t(64u), partitionSize));
+				auto buildPartition = [&](size_t partition)
 					{
-						continue;
-					}
-					glm::ivec3 octreeCenter{};
-					glm::ivec3 octreeExtents{};
-					GetConservativeOctreeBounds(
-						record->m_worldBounds,
-						octreeCenter,
-						octreeExtents);
-					octree->Update(octreeCenter, octreeExtents, handle);
+						SAILOR_PROFILE_SCOPE("Build scene spatial partition");
+						const size_t end = (std::min)(numHandles, (partition + 1u) * partitionSize);
+						for (size_t i = partition * partitionSize; i < end; ++i)
+						{
+							const auto handle = (*handles)[i];
+							const RHI::RHISceneInstanceRecord* record = nullptr;
+							if (!version->m_sceneVersion->Resolve(handle, record) || !record)
+							{
+								continue;
+							}
+							glm::ivec3 center{}, extents{};
+							GetConservativeOctreeBounds(record->m_worldBounds, center, extents);
+							index->Update(center, extents, handle, partition);
+						}
+					};
+				if (numPartitions == 1u)
+				{
+					buildPartition(0u);
 				}
+				else
+				{
+					TVector<Tasks::ITaskPtr> tasks;
+					for (size_t partition = 0u; partition < numPartitions; ++partition)
+					{
+						auto task = Tasks::CreateTask("Build scene spatial partition",
+							[&, partition]() { buildPartition(partition); }, EThreadType::Worker);
+						task->Run();
+						tasks.Add(task);
+					}
+					for (auto& task : tasks)
+					{
+						task->Wait();
+					}
+				}
+				return index;
 			};
-		if (bRebuildStatic)
-		{
-			rebuildSpatialRoot(version->m_sceneVersion->m_staticHandles, version->m_staticOctree);
-		}
-		if (bRebuildStationary)
-		{
-			rebuildSpatialRoot(
-				version->m_sceneVersion->m_stationaryHandles,
-				version->m_stationaryOctree);
-		}
-		if (bRebuildDynamic)
-		{
-			rebuildSpatialRoot(version->m_sceneVersion->m_dynamicHandles, version->m_dynamicOctree);
-		}
+		version->m_staticOctree = bRebuildStatic ?
+			rebuildSpatialRoot(version->m_sceneVersion->m_staticHandles) : m_publishedSceneVersion->m_staticOctree;
+		version->m_stationaryOctree = bRebuildStationary ?
+			rebuildSpatialRoot(version->m_sceneVersion->m_stationaryHandles) : m_publishedSceneVersion->m_stationaryOctree;
+		version->m_dynamicOctree = bRebuildDynamic ?
+			rebuildSpatialRoot(version->m_sceneVersion->m_dynamicHandles) : m_publishedSceneVersion->m_dynamicOctree;
 	}
 	m_publishedSceneVersion = std::move(version);
 }
@@ -483,14 +472,11 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	const uint64_t materialContentRevision = Material::GetGlobalContentRevision();
 	const bool bCheckMaterialRevisions = materialContentRevision != m_lastMaterialContentRevision;
 	bool bHasCustomDepthShadowCasters = false;
-	auto& dirtyComponents = m_componentScanScratch;
-	dirtyComponents.Clear(false);
-	dirtyComponents.Reserve(m_components.Num());
-	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	auto needsUpdate = [this, bCheckMaterialRevisions](size_t componentIndex, bool& bHasCustomDepthShadowCasters)
 	{
 		if (!IsComponentRegistered(componentIndex))
 		{
-			continue;
+			return false;
 		}
 
 		auto& registeredData = m_components[componentIndex];
@@ -530,16 +516,8 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			bNeedsUpdate = bMaterialsChanged;
 		}
 
-		if (bNeedsUpdate)
-		{
-			dirtyComponents.Add(componentIndex);
-		}
-	}
-	if (dirtyComponents.IsEmpty())
-	{
-		m_lastMaterialContentRevision = materialContentRevision;
-		return nullptr;
-	}
+		return bNeedsUpdate;
+	};
 
 	const size_t currentFrame = GetWorld()->GetCurrentFrame();
 	// Dirty-proxy workers only read the last published scene. Keep that immutable
@@ -671,13 +649,23 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 						result.m_shadowCaster = data.m_shadowCaster;
 						result.m_state = owner->GetMobilityType() == EMobilityType::Static ?
 							EPreparedProxyState::Static : EPreparedProxyState::Stationary;
-						result.m_staticProxy.m_staticMeshEcs = componentIndex;
-						result.m_staticProxy.m_mobility = owner->GetMobilityType();
-						result.m_staticProxy.m_worldMatrix = ownerWorldMatrix;
-						result.m_staticProxy.m_worldAabb = worldBounds;
-						result.m_staticProxy.m_frame = currentFrame;
-						result.m_staticProxy.m_skeletonOffset = result.m_skeletonOffset;
-						result.m_staticProxy.m_bCastShadows = data.ShouldCastShadow();
+						result.m_sceneUpdate.m_handle = *renderHandle;
+						auto& record = result.m_sceneUpdate.m_record;
+						// Retain immutable mesh/material metadata; never expose ECS
+						// storage to the next render submission. Binding generations
+						// are retained separately by its material publication cutoff.
+						record = *previousRecord;
+						record.m_mobility = owner->GetMobilityType();
+						record.m_worldMatrix = ownerWorldMatrix;
+						record.m_worldBounds = worldBounds;
+						record.m_skeletonOffset = result.m_skeletonOffset;
+						if (record.m_mobility != previousRecord->m_mobility)
+						{
+							result.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Mobility);
+						}
+						result.m_spatialChangeMask = GetSpatialChangeMask(previousRecord->m_mobility) |
+							GetSpatialChangeMask(record.m_mobility);
+						result.m_sceneUpdate.m_changeMask = result.m_changeMask;
 						result.m_bStateOnly = true;
 						return result;
 					}
@@ -708,7 +696,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 			result.m_state = owner->GetMobilityType() == EMobilityType::Static ?
 				EPreparedProxyState::Static : EPreparedProxyState::Stationary;
-			auto& proxy = result.m_staticProxy;
+			auto& proxy = result.m_staticProxy.emplace();
 			proxy.m_staticMeshEcs = componentIndex;
 			proxy.m_mobility = owner->GetMobilityType();
 			proxy.m_worldMatrix = ownerWorldMatrix;
@@ -793,41 +781,49 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			return result;
 		};
 
-	auto& preparedUpdates = m_preparedUpdatesScratch;
-	preparedUpdates.Clear(false);
-	preparedUpdates.Resize(dirtyComponents.Num());
-	if (dirtyComponents.Num() <= NumDirtyComponentsPerTask)
-	{
-		for (size_t index = 0; index < dirtyComponents.Num(); ++index)
+	auto& batches = m_preparedBatchesScratch;
+	const size_t numBatches = (m_components.Num() + NumDirtyComponentsPerTask - 1u) / NumDirtyComponentsPerTask;
+	batches.Resize(numBatches);
+	auto prepareBatch = [&](size_t batchIndex)
 		{
-			preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);
+			SAILOR_PROFILE_SCOPE("Prepare dirty mesh proxies");
+			auto& batch = batches[batchIndex];
+			batch.m_updates.Clear(false);
+			batch.m_sceneUpdates.Clear(false);
+			batch.m_bHasCustomDepthShadowCasters = false;
+			const size_t end = (std::min)(m_components.Num(), (batchIndex + 1u) * NumDirtyComponentsPerTask);
+			for (size_t index = batchIndex * NumDirtyComponentsPerTask; index < end; ++index)
+			{
+				if (needsUpdate(index, batch.m_bHasCustomDepthShadowCasters))
+				{
+					auto update = prepareProxyUpdate(index);
+					if (update.m_bStateOnly)
+					{
+						batch.m_sceneUpdates.Add(std::move(update.m_sceneUpdate));
+					}
+					batch.m_updates.Add(std::move(update));
+				}
+			}
+		};
+	if (numBatches <= 1u || !App::GetSubmodule<Tasks::Scheduler>())
+	{
+		for (size_t index = 0u; index < numBatches; ++index)
+		{
+			prepareBatch(index);
 		}
 	}
 	else
 	{
 		auto& tasks = m_prepareTasksScratch;
 		tasks.Clear(false);
-		const size_t numTasks = (dirtyComponents.Num() + NumDirtyComponentsPerTask - 1) / NumDirtyComponentsPerTask;
-		tasks.Reserve(numTasks);
-		for (size_t taskIndex = 0; taskIndex < numTasks; ++taskIndex)
+		tasks.Reserve(numBatches);
+		for (size_t index = 0u; index < numBatches; ++index)
 		{
-			const size_t beginIndex = taskIndex * NumDirtyComponentsPerTask;
-			const size_t endIndex = (std::min)(beginIndex + NumDirtyComponentsPerTask, dirtyComponents.Num());
-			auto task = Tasks::CreateTask(
-				"StaticMeshRendererECS:Prepare Dirty Proxies",
-				[beginIndex, endIndex, &dirtyComponents, &preparedUpdates, prepareProxyUpdate]()
-				{
-					SAILOR_PROFILE_SCOPE("Prepare dirty mesh proxies");
-					for (size_t index = beginIndex; index < endIndex; ++index)
-					{
-						preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);
-					}
-				},
-				EThreadType::Worker);
+			auto task = Tasks::CreateTask("StaticMeshRendererECS:Prepare Dirty Proxies",
+				[&, index]() { prepareBatch(index); }, EThreadType::Worker);
 			task->Run();
 			tasks.Add(task);
 		}
-
 		for (auto& task : tasks)
 		{
 			task->Wait();
@@ -840,196 +836,214 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	const bool bPreviousHasCustomDepthShadowCasters =
 		m_bHasCustomDepthShadowCasters;
 	uint8_t spatialChangeMask = 0u;
-	for (auto& update : preparedUpdates)
 	{
-		if (!IsComponentRegistered(update.m_componentIndex))
+		SAILOR_PROFILE_SCOPE("Apply prepared mesh batches");
+		for (auto& batch : batches)
 		{
-			continue;
-		}
-
-		auto& data = m_components[update.m_componentIndex];
-		auto cacheMaterialRevisions = [&data]()
+			bHasCustomDepthShadowCasters |= batch.m_bHasCustomDepthShadowCasters;
+			for (auto& update : batch.m_updates)
 			{
-				data.m_materialContentRevisions.Resize(data.GetMaterials().Num() + 1u);
-				for (size_t materialIndex = 0u;
-					materialIndex < data.GetMaterials().Num(); ++materialIndex)
+				if (!IsComponentRegistered(update.m_componentIndex))
 				{
-					const auto& material = data.GetMaterials()[materialIndex];
-					data.m_materialContentRevisions[materialIndex] = material ?
-						material->GetContentRevision() : 0ull;
+					continue;
 				}
-				data.m_materialContentRevisions[data.GetMaterials().Num()] =
-					CalculateMaterialRenderMetadataSignature(data.GetMaterials());
-			};
-		if (update.m_state == EPreparedProxyState::Pending)
-		{
-			data.m_bIsDirty = true;
-			continue;
-		}
-		if (update.m_state == EPreparedProxyState::PendingMaterialVersion)
-		{
-			bMaterialVersionsPending = true;
-			continue;
-		}
-		if (update.m_state == EPreparedProxyState::MaterialVersionOnly)
-		{
-			cacheMaterialRevisions();
-			continue;
-		}
 
-		if (update.m_state == EPreparedProxyState::Remove)
-		{
-			if (data.m_shadowCaster)
-			{
-				data.m_shadowCaster.Clear();
-				bShadowCastersChanged = true;
-			}
-			data.m_materialContentRevisions.Clear();
-			data.m_bIsDirty = false;
-			RHI::RenderInstanceHandle* renderHandle = nullptr;
-			if (m_rhiScene && m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
-			{
-				RHI::RHISceneInstanceRecord previousRecord;
-				if (m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
-				{
-					spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
-				}
-				bSceneRecordsChanged |= m_rhiScene->RemoveInstance(*renderHandle);
-				m_renderInstanceHandles.Remove(update.m_componentIndex);
-			}
-			continue;
-		}
-
-		if (data.m_shadowCaster && update.m_shadowCaster &&
-			AreShadowCastersEqual(*data.m_shadowCaster, *update.m_shadowCaster))
-		{
-			update.m_shadowCaster = data.m_shadowCaster;
-		}
-		else if (data.m_shadowCaster != update.m_shadowCaster)
-		{
-			data.m_shadowCaster = update.m_shadowCaster;
-			bShadowCastersChanged = true;
-		}
-		if (update.m_bStateOnly &&
-			(update.m_changeMask & RHI::ToMask(RHI::ESceneChangeBit::Transform)) != 0u &&
-			update.m_staticProxy.m_bCastShadows)
-		{
-			bShadowCastersChanged = true;
-		}
-
-		update.m_staticProxy.m_shadowCaster = data.m_shadowCaster;
-		if (update.m_staticProxy.m_shadowCaster)
-		{
-			update.m_staticProxy.m_shadowCaster->m_mobility = update.m_staticProxy.m_mobility;
-		}
-		if (m_rhiScene)
-		{
-			RHI::RHISceneInstanceRecord sceneRecord;
-			sceneRecord.m_producerKey = update.m_componentIndex;
-			sceneRecord.m_mobility = update.m_staticProxy.m_mobility;
-			sceneRecord.m_worldMatrix = update.m_staticProxy.m_worldMatrix;
-			sceneRecord.m_worldBounds = update.m_staticProxy.m_worldAabb;
-			sceneRecord.m_topologyRevision = currentFrame;
-			sceneRecord.m_materialRevision = Material::GetGlobalContentRevision();
-			sceneRecord.m_skeletonOffset = update.m_staticProxy.m_skeletonOffset;
-			sceneRecord.m_renderFlags = update.m_staticProxy.m_bCastShadows ? 1u : 0u;
-
-			RHI::RenderInstanceHandle* renderHandle = nullptr;
-			if (m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
-			{
-				RHI::RHISceneInstanceRecord previousRecord;
-				const bool bResolvedPrevious =
-					m_rhiScene->ResolveCurrent(*renderHandle, previousRecord);
-				if (bResolvedPrevious)
-				{
-					const RHI::SceneChangeMask topologyChanges =
-						RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology) |
-						RHI::ToMask(RHI::ESceneChangeBit::Material) |
-						RHI::ToMask(RHI::ESceneChangeBit::RenderState) |
-						RHI::ToMask(RHI::ESceneChangeBit::ShadowState);
-					bool bCanReuseTopology = (update.m_changeMask & topologyChanges) == 0u;
-					if (bCanReuseTopology &&
-						(update.m_changeMask & RHI::ToMask(RHI::ESceneChangeBit::Transform)) != 0u)
+				auto& data = m_components[update.m_componentIndex];
+				auto cacheMaterialRevisions = [&data]()
 					{
-						const auto previousResource =
-							previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
-						bCanReuseTopology = previousResource &&
-							previousResource->m_bMeshTransformsAreLocal;
-					}
-					if (bCanReuseTopology)
-					{
-						sceneRecord.m_topology = previousRecord.m_topology;
-						sceneRecord.m_topologyRevision = previousRecord.m_topologyRevision;
-						if ((update.m_changeMask &
-							RHI::ToMask(RHI::ESceneChangeBit::Material)) == 0u)
+						data.m_materialContentRevisions.Resize(data.GetMaterials().Num() + 1u);
+						for (size_t materialIndex = 0u;
+							materialIndex < data.GetMaterials().Num(); ++materialIndex)
 						{
-							sceneRecord.m_materialRevision = previousRecord.m_materialRevision;
+							const auto& material = data.GetMaterials()[materialIndex];
+							data.m_materialContentRevisions[materialIndex] = material ?
+								material->GetContentRevision() : 0ull;
+						}
+						data.m_materialContentRevisions[data.GetMaterials().Num()] =
+							CalculateMaterialRenderMetadataSignature(data.GetMaterials());
+					};
+				if (update.m_state == EPreparedProxyState::Pending)
+				{
+					data.m_bIsDirty = true;
+					continue;
+				}
+				if (update.m_state == EPreparedProxyState::PendingMaterialVersion)
+				{
+					bMaterialVersionsPending = true;
+					continue;
+				}
+				if (update.m_state == EPreparedProxyState::MaterialVersionOnly)
+				{
+					cacheMaterialRevisions();
+					continue;
+				}
+
+				if (update.m_state == EPreparedProxyState::Remove)
+				{
+					if (data.m_shadowCaster)
+					{
+						data.m_shadowCaster.Clear();
+						bShadowCastersChanged = true;
+					}
+					data.m_materialContentRevisions.Clear();
+					data.m_bIsDirty = false;
+					RHI::RenderInstanceHandle* renderHandle = nullptr;
+					if (m_rhiScene && m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
+					{
+						RHI::RHISceneInstanceRecord previousRecord;
+						if (m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+						{
+							spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
+						}
+						bSceneRecordsChanged |= m_rhiScene->RemoveInstance(*renderHandle);
+						m_renderInstanceHandles.Remove(update.m_componentIndex);
+					}
+					continue;
+				}
+
+				if (update.m_bStateOnly)
+				{
+					bShadowCastersChanged |= data.ShouldCastShadow();
+					spatialChangeMask |= update.m_spatialChangeMask;
+				}
+				else
+				{
+					if (data.m_shadowCaster && update.m_shadowCaster &&
+						AreShadowCastersEqual(*data.m_shadowCaster, *update.m_shadowCaster))
+					{
+						update.m_shadowCaster = data.m_shadowCaster;
+					}
+					else if (data.m_shadowCaster != update.m_shadowCaster)
+					{
+						data.m_shadowCaster = update.m_shadowCaster;
+						bShadowCastersChanged = true;
+					}
+
+					update.m_staticProxy->m_shadowCaster = data.m_shadowCaster;
+					if (update.m_staticProxy->m_shadowCaster)
+					{
+						update.m_staticProxy->m_shadowCaster->m_mobility = update.m_staticProxy->m_mobility;
+					}
+					if (m_rhiScene)
+					{
+						RHI::RHISceneInstanceRecord sceneRecord;
+						sceneRecord.m_producerKey = update.m_componentIndex;
+						sceneRecord.m_mobility = update.m_staticProxy->m_mobility;
+						sceneRecord.m_worldMatrix = update.m_staticProxy->m_worldMatrix;
+						sceneRecord.m_worldBounds = update.m_staticProxy->m_worldAabb;
+						sceneRecord.m_topologyRevision = currentFrame;
+						sceneRecord.m_materialRevision = Material::GetGlobalContentRevision();
+						sceneRecord.m_skeletonOffset = update.m_staticProxy->m_skeletonOffset;
+						sceneRecord.m_renderFlags = update.m_staticProxy->m_bCastShadows ? 1u : 0u;
+
+						RHI::RenderInstanceHandle* renderHandle = nullptr;
+						if (m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
+						{
+							RHI::RHISceneInstanceRecord previousRecord;
+							const bool bResolvedPrevious =
+								m_rhiScene->ResolveCurrent(*renderHandle, previousRecord);
+							if (bResolvedPrevious)
+							{
+								const RHI::SceneChangeMask topologyChanges =
+									RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology) |
+									RHI::ToMask(RHI::ESceneChangeBit::Material) |
+									RHI::ToMask(RHI::ESceneChangeBit::RenderState) |
+									RHI::ToMask(RHI::ESceneChangeBit::ShadowState);
+								bool bCanReuseTopology = (update.m_changeMask & topologyChanges) == 0u;
+								if (bCanReuseTopology &&
+									(update.m_changeMask & RHI::ToMask(RHI::ESceneChangeBit::Transform)) != 0u)
+								{
+									const auto previousResource =
+										previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
+									bCanReuseTopology = previousResource &&
+										previousResource->m_bMeshTransformsAreLocal;
+								}
+								if (bCanReuseTopology)
+								{
+									sceneRecord.m_topology = previousRecord.m_topology;
+									sceneRecord.m_topologyRevision = previousRecord.m_topologyRevision;
+									if ((update.m_changeMask &
+										RHI::ToMask(RHI::ESceneChangeBit::Material)) == 0u)
+									{
+										sceneRecord.m_materialRevision = previousRecord.m_materialRevision;
+									}
+								}
+								else
+								{
+									update.m_changeMask |=
+										RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology);
+									sceneRecord.m_topology =
+										RHI::RHISceneProxyResourcePtr::Make(std::move(*update.m_staticProxy));
+								}
+								if (previousRecord.m_mobility != sceneRecord.m_mobility)
+								{
+									update.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Mobility);
+								}
+								if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
+								{
+									sceneRecord.m_shadowRevision = resource->m_shadowRevision;
+								}
+							}
+							const RHI::SceneChangeMask spatialChanges =
+								RHI::ToMask(RHI::ESceneChangeBit::Transform) |
+								RHI::ToMask(RHI::ESceneChangeBit::Bounds) |
+								RHI::ToMask(RHI::ESceneChangeBit::Mobility);
+							const bool bUpdated = m_rhiScene->UpdateInstance(
+								*renderHandle,
+								sceneRecord,
+								update.m_changeMask);
+							bSceneRecordsChanged |= bUpdated;
+							if (bUpdated && (update.m_changeMask & spatialChanges) != 0u)
+							{
+								if (bResolvedPrevious)
+								{
+									spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
+								}
+								spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
+							}
+						}
+						else
+						{
+							sceneRecord.m_topology =
+								RHI::RHISceneProxyResourcePtr::Make(std::move(*update.m_staticProxy));
+							if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
+							{
+								sceneRecord.m_shadowRevision = resource->m_shadowRevision;
+							}
+							m_renderInstanceHandles[update.m_componentIndex] = m_rhiScene->AddInstance(sceneRecord);
+							bSceneRecordsChanged = true;
+							spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
 						}
 					}
-					else
-					{
-						update.m_changeMask |=
-							RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology);
-						sceneRecord.m_topology =
-							RHI::RHISceneProxyResourcePtr::Make(std::move(update.m_staticProxy));
-					}
-					if (previousRecord.m_mobility != sceneRecord.m_mobility)
-					{
-						update.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Mobility);
-					}
-					if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
-					{
-						sceneRecord.m_shadowRevision = resource->m_shadowRevision;
-					}
+
 				}
-				const RHI::SceneChangeMask spatialChanges =
-					RHI::ToMask(RHI::ESceneChangeBit::Transform) |
-					RHI::ToMask(RHI::ESceneChangeBit::Bounds) |
-					RHI::ToMask(RHI::ESceneChangeBit::Mobility);
-				const bool bUpdated = m_rhiScene->UpdateInstance(
-					*renderHandle,
-					sceneRecord,
-					update.m_changeMask);
-				bSceneRecordsChanged |= bUpdated;
-				if (bUpdated && (update.m_changeMask & spatialChanges) != 0u)
+
+				data.m_skeletonOffset = update.m_skeletonOffset;
+				if (!update.m_bStateOnly || bCheckMaterialRevisions)
 				{
-					if (bResolvedPrevious)
-					{
-						spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
-					}
-					spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
+					cacheMaterialRevisions();
 				}
+
+				ObjectPtr ownerObject = data.GetOwner();
+				GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
+				if (owner)
+				{
+					data.m_frameLastChange = owner->GetTransformComponent().GetFrameLastChange();
+					if ((update.m_state == EPreparedProxyState::Static && data.m_frameLastChange == 0) ||
+						data.m_frameLastChange != owner->GetFrameLastChange())
+					{
+						UpdateGameObject(owner, currentFrame);
+					}
+				}
+				data.m_bIsDirty = false;
 			}
-			else
+			if (m_rhiScene && !batch.m_sceneUpdates.IsEmpty())
 			{
-				sceneRecord.m_topology =
-					RHI::RHISceneProxyResourcePtr::Make(std::move(update.m_staticProxy));
-				if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
-				{
-					sceneRecord.m_shadowRevision = resource->m_shadowRevision;
-				}
-				m_renderInstanceHandles[update.m_componentIndex] = m_rhiScene->AddInstance(sceneRecord);
-				bSceneRecordsChanged = true;
-				spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
+				bSceneRecordsChanged |= m_rhiScene->UpdateInstances(batch.m_sceneUpdates) != 0u;
 			}
 		}
-
-		data.m_skeletonOffset = update.m_skeletonOffset;
-		cacheMaterialRevisions();
-
-		ObjectPtr ownerObject = data.GetOwner();
-		GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
-		if (owner)
-		{
-			data.m_frameLastChange = owner->GetTransformComponent().GetFrameLastChange();
-			if ((update.m_state == EPreparedProxyState::Static && data.m_frameLastChange == 0) ||
-				data.m_frameLastChange != owner->GetFrameLastChange())
-			{
-				UpdateGameObject(owner, currentFrame);
-			}
-		}
-		data.m_bIsDirty = false;
 	}
+
 	if (!bMaterialVersionsPending)
 	{
 		m_lastMaterialContentRevision = materialContentRevision;
@@ -1065,8 +1079,7 @@ void StaticMeshRendererECS::EndPlay()
 	m_sceneVersionRevision = 0ull;
 	m_spatialRevision = 0ull;
 	m_shadowCastersRevision = 0ull;
-	m_componentScanScratch.Clear();
-	m_preparedUpdatesScratch.Clear();
+	m_preparedBatchesScratch.Clear();
 	m_prepareTasksScratch.Clear();
 	m_bHasCustomDepthShadowCasters = false;
 }

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -8,6 +8,7 @@
 #include "Memory/Memory.h"
 #include "RHI/SceneView.h"
 #include "Memory/UniquePtr.hpp"
+#include <optional>
 
 namespace Sailor
 {
@@ -95,11 +96,20 @@ namespace Sailor
 			size_t m_componentIndex = ECS::InvalidIndex;
 			EPreparedProxyState m_state = EPreparedProxyState::Remove;
 			uint32_t m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
-			RHI::RHISceneViewProxy m_staticProxy{};
+			std::optional<RHI::RHISceneViewProxy> m_staticProxy{};
+			RHI::RHISceneInstanceUpdate m_sceneUpdate{};
 			RHI::RHIShadowCasterProxyPtr m_shadowCaster{};
 			Math::AABB m_worldBounds{};
 			RHI::SceneChangeMask m_changeMask = RHI::ToMask(RHI::ESceneChangeBit::None);
 			bool m_bStateOnly = false;
+			uint8_t m_spatialChangeMask = 0u;
+		};
+
+		struct PreparedProxyBatch
+		{
+			TVector<PreparedProxyUpdate> m_updates{};
+			TVector<RHI::RHISceneInstanceUpdate> m_sceneUpdates{};
+			bool m_bHasCustomDepthShadowCasters = false;
 		};
 
 		SAILOR_API virtual void OnComponentUnregistered(size_t index, StaticMeshRendererData& component) override;
@@ -112,8 +122,7 @@ namespace Sailor
 		uint64_t m_spatialRevision = 0ull;
 		uint64_t m_shadowCastersRevision = 0ull;
 		uint64_t m_lastMaterialContentRevision = 0;
-		TVector<size_t> m_componentScanScratch{};
-		TVector<PreparedProxyUpdate> m_preparedUpdatesScratch{};
+		TVector<PreparedProxyBatch> m_preparedBatchesScratch{};
 		TVector<Tasks::ITaskPtr> m_prepareTasksScratch{};
 		bool m_bHasCustomDepthShadowCasters = false;
 	};

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -1052,7 +1052,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 			}
 			m_orderedDrawItems.Clear(false);
 			syncSharedResources.Unlock();
-		}, EThreadType::RHI);
+		}, EThreadType::Worker);
 
 	return res;
 }

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -164,6 +164,726 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
 	return material;
 }
 
+Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGraph, const RHI::RHISceneViewSnapshot& sceneView)
+{
+	SAILOR_PROFILE_FUNCTION();
+	if (!sceneView.m_submissionContext || sceneView.m_shadowMapsToUpdate.IsEmpty())
+	{
+		return {};
+	}
+	std::string virtualizeInstancePayloadsSetting;
+	const bool bVirtualizeInstancePayloads =
+		!TryGetString("VirtualizeInstancePayloads", virtualizeInstancePayloadsSetting) ||
+		virtualizeInstancePayloadsSetting != "false";
+
+	// Shader cache misses can wait for Worker jobs, so material/arena preparation
+	// uses RHI. Independent packet finalization runs on the general Worker pool.
+	return Tasks::CreateTask("Prepare ShadowPrepassNode " + std::to_string(sceneView.m_frame),
+		[this, holdRhiResources = frameGraph, &sceneView, bVirtualizeInstancePayloads]()
+		{
+			SAILOR_PROFILE_SCOPE("Prepare shadow packets");
+			const uint64_t materialSubmissionId = sceneView.m_submissionContext->GetSubmissionId();
+			auto submissionResources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+				this, sceneView.m_cameraIndex, 0u);
+			m_syncSharedResources.Lock();
+			const uint32_t NumShadowPasses = (uint32_t)sceneView.m_shadowMapsToUpdate.Num();
+			const size_t opaqueQueueTag = "Opaque"_h.GetHash();
+			const size_t maskedQueueTag = "Masked"_h.GetHash();
+			const size_t staticPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Static);
+			const size_t stationaryPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Stationary);
+			const bool bUsesPagedArenas = bVirtualizeInstancePayloads;
+			auto usesPagedArena = [&](size_t payloadIndex)
+				{
+					return bUsesPagedArenas &&
+						(payloadIndex == staticPayloadIndex ||
+							payloadIndex == stationaryPayloadIndex);
+				};
+			auto buildPayloadCacheSlot = [&](
+				uint64_t viewKey,
+				EShadowType shadowType,
+				EMobilityType mobility)
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					size_t cacheSlot = usesPagedArena(index) ?
+						Fnv1aOffsetBasis : viewKey;
+					if (usesPagedArena(index))
+					{
+						HashCombine(cacheSlot, static_cast<uint32_t>(shadowType), index);
+					}
+					else
+					{
+						HashCombine(cacheSlot, sceneView.m_cameraIndex, index);
+					}
+					return cacheSlot;
+				};
+			submissionResources->m_activeShadowViews.Clear(false);
+			submissionResources->m_activeShadowViews.Reserve(NumShadowPasses);
+			submissionResources->m_numActiveShadowViews = NumShadowPasses;
+			auto& shadowPayloadRevisions = submissionResources->m_shadowPayloadRevisions;
+			auto& bBuildShadowPayloads = submissionResources->m_buildShadowPayloads;
+			auto& bShadowPayloadComplete = submissionResources->m_shadowPayloadComplete;
+			shadowPayloadRevisions.Clear(false);
+			bBuildShadowPayloads.Clear(false);
+			bShadowPayloadComplete.Clear(false);
+			shadowPayloadRevisions.Resize(NumShadowPasses);
+			bBuildShadowPayloads.Resize(NumShadowPasses);
+			bShadowPayloadComplete.Resize(NumShadowPasses);
+			for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
+			{
+				const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
+				size_t viewKey = Fnv1aOffsetBasis;
+				HashCombine(
+					viewKey,
+					shadowPass.m_lighMatrixIndex,
+					static_cast<uint32_t>(shadowPass.m_shadowType));
+				auto& viewResources = submissionResources->m_shadowViewCache[viewKey];
+				if (!viewResources)
+				{
+					viewResources = TSharedPtr<SubmissionResources::ShadowViewResources>::Make();
+				}
+				viewResources->Begin(viewKey);
+				submissionResources->m_activeShadowViews.Add(viewResources);
+
+				for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
+				{
+					auto& revision = shadowPayloadRevisions[passIndex][index];
+					revision = Fnv1aOffsetBasis;
+					HashCombine(
+						revision,
+						index,
+						shadowPass.m_lighMatrixIndex,
+						static_cast<uint32_t>(shadowPass.m_shadowType),
+						std::hash<glm::mat4>{}(shadowPass.m_lightMatrix),
+						std::hash<glm::vec3>{}(glm::vec3(sceneView.m_cameraTransform.m_position)));
+					bBuildShadowPayloads[passIndex][index] = true;
+					bShadowPayloadComplete[passIndex][index] = true;
+				}
+				if (bUsesPagedArenas)
+				{
+					for (const EMobilityType mobility :
+						{ EMobilityType::Static, EMobilityType::Stationary })
+					{
+						const size_t payloadIndex =
+							RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+						auto& arenaRevision =
+							shadowPayloadRevisions[passIndex][payloadIndex];
+						arenaRevision = Fnv1aOffsetBasis;
+						HashCombine(
+							arenaRevision,
+							payloadIndex,
+							static_cast<uint32_t>(shadowPass.m_shadowType),
+							sceneView.m_submissionContext->GetMaterialRevision(),
+							sceneView.GetMobilityRevision(mobility));
+					}
+				}
+
+				if (bVirtualizeInstancePayloads)
+				{
+					for (const EMobilityType mobility :
+						{ EMobilityType::Static, EMobilityType::Stationary })
+					{
+						const size_t index =
+							RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+						const size_t cacheSlot = buildPayloadCacheSlot(
+							viewKey,
+							shadowPass.m_shadowType,
+							mobility);
+						auto payload = usesPagedArena(index) ?
+							m_pagedArenaCache.Find(
+								cacheSlot,
+								shadowPayloadRevisions[passIndex][index],
+								sceneView.m_frame) :
+							m_packetPayloadCache.Find(
+								cacheSlot,
+								shadowPayloadRevisions[passIndex][index],
+								sceneView.m_frame);
+						if (payload)
+						{
+							if (usesPagedArena(index))
+							{
+								viewResources->m_packet.UseSharedArenaPayload(
+									mobility,
+									std::move(payload));
+							}
+							else
+							{
+								viewResources->m_packet.UseSharedPayload(
+									mobility,
+									std::move(payload));
+							}
+							bBuildShadowPayloads[passIndex][index] = false;
+						}
+					}
+				}
+			}
+
+			Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneView.m_frame);
+			m_packetPayloadCache.Evict(sceneView.m_frame);
+
+			TVector<Tasks::TaskPtr<void, void>> finalizeTasks;
+			finalizeTasks.Reserve(NumShadowPasses);
+
+			for (uint32_t passIndex = 0; passIndex < sceneView.m_shadowMapsToUpdate.Num(); passIndex++)
+			{
+				SAILOR_PROFILE_SCOPE("Build shadow packet");
+				const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
+				auto& viewResources =
+					*submissionResources->m_activeShadowViews[passIndex];
+				if (bUsesPagedArenas)
+				{
+					for (const EMobilityType mobility : {EMobilityType::Static, EMobilityType::Stationary})
+					{
+						const size_t arenaPayloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+						if (!bBuildShadowPayloads[passIndex][arenaPayloadIndex])
+						{
+							continue;
+						}
+						const size_t arenaCacheSlot =
+							buildPayloadCacheSlot(viewResources.m_viewKey, shadowPass.m_shadowType, mobility);
+						if (auto payload = m_pagedArenaCache.Find(
+								arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame))
+						{
+							viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(payload));
+							bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
+						}
+						else
+						{
+							m_pagedArenaCache.BeginUpdate(
+								arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame);
+							auto& rangeInstances = submissionResources->m_arenaRangeInstances;
+							auto& rangeStableKeys = submissionResources->m_arenaRangeStableKeys;
+							auto& rangeMaterialVersionRuns = submissionResources->m_arenaRangeMaterialVersionRuns;
+							sceneView.ForEachShadowCaster(mobility,
+								[&](const RHIVisibleShadowCaster& proxy)
+								{
+									const auto* source = proxy.GetSource();
+									if (!source || !proxy.m_resource)
+									{
+										return;
+									}
+									const uint64_t rangeKey =
+										BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource);
+									size_t rangeRevision = proxy.m_resource->m_shadowRevision;
+									HashCombine(rangeRevision, static_cast<uint32_t>(shadowPass.m_shadowType),
+										proxy.GetContentRevision(), std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+										proxy.GetSkeletonOffset());
+									if (proxy.m_record)
+									{
+										HashCombine(rangeRevision, proxy.m_record->m_materialRevision,
+											proxy.m_record->m_shadowRevision, proxy.m_record->m_renderFlags);
+									}
+									for (const auto& shadowMesh : source->m_meshes)
+									{
+										if (shadowMesh.m_customDepthMaterial)
+										{
+											const auto materialVersion =
+												shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
+													materialSubmissionId);
+											HashCombine(
+												rangeRevision, materialVersion ? materialVersion->GetVersionId() : 0ull);
+										}
+									}
+									for (const auto& group : proxy.m_resource->m_proxy.m_instancedGroups)
+									{
+										for (const auto& material : group.m_materials)
+										{
+											if (material && material->GetRenderState().IsRequiredCustomDepthShader())
+											{
+												const auto materialVersion =
+													material->GetVersionForSubmission(materialSubmissionId);
+												HashCombine(rangeRevision,
+													materialVersion ? materialVersion->GetVersionId() : 0ull);
+											}
+										}
+									}
+									if (m_pagedArenaCache.TryReuseRange(rangeKey, rangeRevision))
+									{
+										return;
+									}
+									rangeInstances.Clear(false);
+									rangeStableKeys.Clear(false);
+									rangeMaterialVersionRuns.Clear(false);
+
+									auto addArenaShadowInstance =
+										[&](const RHIMeshPtr& mesh, const glm::mat4& model, size_t renderQueueTag,
+											float baseColorAlpha, uint32_t baseColorSampler, float alphaCutoff,
+											const ShaderSetPtr& customDepthShader,
+											const RHIMaterialPtr& customDepthMaterial,
+											const RHIMaterialVersionPtr& customDepthMaterialVersion, uint64_t stableKey)
+									{
+										if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+										{
+											return;
+										}
+										if (!mesh)
+										{
+											bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+											return;
+										}
+
+										const bool bSkinned =
+											proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+											mesh->m_vertexDescription->HasAttribute(
+												RHIVertexDescription::DefaultBoneIdsBinding) &&
+											mesh->m_vertexDescription->HasAttribute(
+												RHIVertexDescription::DefaultBoneWeightsBinding);
+										const bool bMasked = renderQueueTag == maskedQueueTag;
+										auto depthMaterial = GetOrAddShadowMaterial(
+											mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+										if (customDepthMaterial)
+										{
+											if (auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
+													customDepthMaterial, customDepthMaterialVersion,
+													mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked))
+											{
+												depthMaterial = customShadowMaterial;
+											}
+										}
+										if (!depthMaterial || !depthMaterial->GetVertexShader() ||
+											!depthMaterial->GetFragmentShader())
+										{
+											bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+											return;
+										}
+
+										// Shadow materials are immutable derivatives of the exact source
+										// version resolved for this submission.
+										RHIBatch batch(depthMaterial, mesh);
+										const auto materialBindings = batch.GetMaterialBindings();
+										PerInstanceData data;
+										data.model = model;
+										data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+										data.materialInstance =
+											materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+										data.skeletonOffset =
+											bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+										data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+										data.baseColorAlpha = baseColorAlpha;
+										data.baseColorSampler = baseColorSampler;
+										data.alphaCutoff = alphaCutoff;
+										rangeInstances.Add(std::move(data));
+										rangeStableKeys.Add(stableKey);
+										AppendPackedDrawArenaMaterialVersion(
+											rangeMaterialVersionRuns, batch.m_materialVersion);
+									};
+
+									for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num();
+										++shadowMeshIndex)
+									{
+										const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
+										addArenaShadowInstance(shadowMesh.m_mesh, proxy.ResolveMeshWorldMatrix(shadowMesh),
+											shadowMesh.m_renderQueueTag, shadowMesh.m_baseColorFactor.a,
+											shadowMesh.m_baseColorSampler, shadowMesh.m_alphaCutoff,
+											shadowMesh.m_customDepthShader, shadowMesh.m_customDepthMaterial,
+											shadowMesh.m_customDepthMaterial
+												? shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
+													  materialSubmissionId)
+												: RHIMaterialVersionPtr{},
+											BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(), 0u,
+												static_cast<uint32_t>(shadowMeshIndex), 0u));
+									}
+
+									const auto& topology = proxy.m_resource->m_proxy;
+									for (size_t groupIndex = 0u; groupIndex < topology.m_instancedGroups.Num();
+										++groupIndex)
+									{
+										const auto& group = topology.m_instancedGroups[groupIndex];
+										if (!group.m_bCastShadows)
+										{
+											continue;
+										}
+										for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+										{
+											const size_t renderQueueTag = meshIndex < group.m_renderQueueTags.Num()
+												? group.m_renderQueueTags[meshIndex]
+												: 0u;
+											ShaderSetPtr customDepthShader;
+											RHIMaterialPtr customDepthMaterial;
+											if (meshIndex < group.m_sourceMaterialShaders.Num() &&
+												group.m_sourceMaterialShaders[meshIndex] &&
+												meshIndex < group.m_materials.Num() && group.m_materials[meshIndex] &&
+												group.m_materials[meshIndex]
+													->GetRenderState()
+													.IsRequiredCustomDepthShader())
+											{
+												customDepthShader = group.m_sourceMaterialShaders[meshIndex];
+												customDepthMaterial = group.m_materials[meshIndex];
+											}
+											for (size_t instanceIndex = 0u;
+												instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
+											{
+												addArenaShadowInstance(group.m_meshes[meshIndex],
+													proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex),
+													renderQueueTag,
+													meshIndex < group.m_baseColorFactors.Num()
+														? group.m_baseColorFactors[meshIndex].a
+														: 1.0f,
+													meshIndex < group.m_baseColorSamplers.Num()
+														? group.m_baseColorSamplers[meshIndex]
+														: 0u,
+													meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex]
+																						   : 0.5f,
+													customDepthShader, customDepthMaterial,
+													customDepthMaterial
+														? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
+														: RHIMaterialVersionPtr{},
+													BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
+														static_cast<uint32_t>(groupIndex + 1u),
+														static_cast<uint32_t>(meshIndex),
+														static_cast<uint32_t>(instanceIndex)));
+											}
+										}
+									}
+									if (!m_pagedArenaCache.ReplaceRange(rangeKey, rangeRevision, rangeInstances,
+											rangeStableKeys, &rangeMaterialVersionRuns))
+									{
+										bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+									}
+								});
+
+							auto arenaPayload =
+								m_pagedArenaCache.EndUpdate(bShadowPayloadComplete[passIndex][arenaPayloadIndex]);
+							viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(arenaPayload));
+							rangeInstances.Clear(false);
+							rangeStableKeys.Clear(false);
+							rangeMaterialVersionRuns.Clear(false);
+							bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
+						}
+					}
+				}
+				for (const auto& proxy : shadowPass.m_meshList)
+				{
+					const auto* source = proxy.GetSource();
+					if (!source)
+					{
+						continue;
+					}
+					const EMobilityType payloadMobility = proxy.GetMobility();
+					const size_t payloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+					if (!bBuildShadowPayloads[passIndex][payloadIndex] && !usesPagedArena(payloadIndex))
+					{
+						continue;
+					}
+
+					for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num(); ++shadowMeshIndex)
+					{
+						const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
+						const auto& mesh = sceneView.ResolveMesh(proxy, shadowMeshIndex);
+						if (!mesh)
+						{
+							if (shadowMesh.m_renderQueueTag == opaqueQueueTag ||
+								shadowMesh.m_renderQueueTag == maskedQueueTag)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+							}
+							continue;
+						}
+						const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(shadowMesh);
+
+						if (shadowMesh.m_maxCameraDistance < (std::numeric_limits<float>::max)())
+						{
+							Math::AABB worldBounds = mesh->m_bounds;
+							worldBounds.Apply(meshWorldMatrix);
+							const glm::vec3 cameraPosition(sceneView.m_cameraTransform.m_position);
+							const glm::vec3 closestPoint = glm::clamp(cameraPosition, worldBounds.m_min, worldBounds.m_max);
+							if (glm::distance(cameraPosition, closestPoint) > shadowMesh.m_maxCameraDistance)
+							{
+								continue;
+							}
+						}
+						const size_t renderQueueTag = shadowMesh.m_renderQueueTag;
+						if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+						{
+							continue;
+						}
+
+						const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+							mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+							mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+						const bool bMasked = renderQueueTag == maskedQueueTag;
+						auto depthMaterial =
+							GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+						if (shadowMesh.m_customDepthMaterial)
+						{
+							auto customShadowMaterial = GetOrAddCustomShadowMaterial(shadowMesh.m_customDepthShader,
+								shadowMesh.m_customDepthMaterial,
+								shadowMesh.m_customDepthMaterial->GetVersionForSubmission(materialSubmissionId),
+								mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
+							if (customShadowMaterial)
+							{
+								depthMaterial = customShadowMaterial;
+							}
+						}
+
+						const bool bIsDepthMaterialReady =
+							depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
+
+						if (!bIsDepthMaterialReady)
+						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
+							continue;
+						}
+						RHIBatch batch(depthMaterial, mesh);
+
+						ShadowPrepassNode::PerInstanceData data;
+						data.model = meshWorldMatrix;
+						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+						const auto materialBindings = batch.GetMaterialBindings();
+						data.materialInstance =
+							materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+						data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+						data.baseColorAlpha = shadowMesh.m_baseColorFactor.a;
+						data.baseColorSampler = shadowMesh.m_baseColorSampler;
+						data.alphaCutoff = shadowMesh.m_alphaCutoff;
+
+						if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
+						{
+							uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+	#if defined(__APPLE__)
+							batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(m_textureBindingCache,
+								shadowMesh.m_materialTextureSamplers, sceneView.m_frame, supportedMeshesPerBatch);
+	#else
+							batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+	#endif
+							batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+							if (!batch.m_textureBindings)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								continue;
+							}
+						}
+						const uint64_t stableKey = BuildPackedDrawStableKey(
+							proxy.m_handle, proxy.GetProducerKey(), 0u, static_cast<uint32_t>(shadowMeshIndex), 0u);
+						if (usesPagedArena(payloadIndex))
+						{
+							if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
+									BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
+									stableKey, payloadMobility))
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+							}
+							continue;
+						}
+
+						viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
+					}
+
+					const auto* topology = proxy.m_resource ? &proxy.m_resource->m_proxy : nullptr;
+					if (!topology)
+					{
+						continue;
+					}
+
+					for (size_t groupIndex = 0u; groupIndex < topology->m_instancedGroups.Num(); ++groupIndex)
+					{
+						const auto& group = topology->m_instancedGroups[groupIndex];
+						if (!group.m_bCastShadows)
+						{
+							continue;
+						}
+
+						for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+						{
+							const size_t renderQueueTag =
+								meshIndex < group.m_renderQueueTags.Num() ? group.m_renderQueueTags[meshIndex] : 0u;
+							if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+							{
+								continue;
+							}
+
+							const auto& sourceMesh = group.m_meshes[meshIndex];
+							if (!sourceMesh)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								continue;
+							}
+
+							const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+								sourceMesh->m_vertexDescription->HasAttribute(
+									RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+								sourceMesh->m_vertexDescription->HasAttribute(
+									RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+							const bool bMasked = renderQueueTag == maskedQueueTag;
+							auto depthMaterial = GetOrAddShadowMaterial(
+								sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+
+							ShaderSetPtr customDepthShader;
+							RHIMaterialPtr customDepthMaterial;
+							if (meshIndex < group.m_sourceMaterialShaders.Num() &&
+								group.m_sourceMaterialShaders[meshIndex] && meshIndex < group.m_materials.Num() &&
+								group.m_materials[meshIndex] &&
+								group.m_materials[meshIndex]->GetRenderState().IsRequiredCustomDepthShader())
+							{
+								customDepthShader = group.m_sourceMaterialShaders[meshIndex];
+								customDepthMaterial = group.m_materials[meshIndex];
+								auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
+									customDepthMaterial,
+									customDepthMaterial ? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
+														: RHIMaterialVersionPtr{},
+									sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
+								if (customShadowMaterial)
+								{
+									depthMaterial = customShadowMaterial;
+								}
+							}
+
+							const bool bIsDepthMaterialReady =
+								depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
+							if (!bIsDepthMaterialReady)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								continue;
+							}
+
+							RHIBatch batchTemplate(depthMaterial, sourceMesh);
+							const auto materialBindings = batchTemplate.GetMaterialBindings();
+							const uint32_t materialInstance =
+								materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+							if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
+							{
+								uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+	#if defined(__APPLE__)
+								const auto& requestedTextures = meshIndex < group.m_materialTextureSamplers.Num()
+									? group.m_materialTextureSamplers[meshIndex]
+									: Framegraph::Details::GetDefaultRequestedTextures();
+								batchTemplate.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
+									m_textureBindingCache, requestedTextures, sceneView.m_frame, supportedMeshesPerBatch);
+	#else
+								batchTemplate.m_textureBindings =
+									App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+	#endif
+								batchTemplate.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+								if (!batchTemplate.m_textureBindings)
+								{
+									bShadowPayloadComplete[passIndex][payloadIndex] = false;
+									continue;
+								}
+							}
+
+							const float baseColorAlpha = meshIndex < group.m_baseColorFactors.Num()
+								? group.m_baseColorFactors[meshIndex].a
+								: 1.0f;
+							const uint32_t baseColorSampler =
+								meshIndex < group.m_baseColorSamplers.Num() ? group.m_baseColorSamplers[meshIndex] : 0u;
+							const float alphaCutoff =
+								meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex] : 0.5f;
+
+							for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
+								++instanceIndex)
+							{
+								if (!proxy.IsInstancedMeshWithinDistance(group, instanceIndex, meshIndex,
+										glm::vec3(sceneView.m_cameraTransform.m_position), group.m_maxShadowDistance))
+								{
+									continue;
+								}
+								const auto& mesh =
+									sceneView.ResolveInstancedMesh(proxy, groupIndex, instanceIndex, meshIndex);
+								if (!mesh)
+								{
+									bShadowPayloadComplete[passIndex][payloadIndex] = false;
+									continue;
+								}
+								const uint64_t stableKey = BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
+									static_cast<uint32_t>(groupIndex + 1u), static_cast<uint32_t>(meshIndex),
+									static_cast<uint32_t>(instanceIndex));
+								const glm::mat4 meshWorldMatrix =
+									proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex);
+								RHIBatch batch = batchTemplate;
+								batch.m_mesh = mesh;
+								if (usesPagedArena(payloadIndex))
+								{
+									if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
+											BuildPackedDrawRangeKey(
+												proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
+											stableKey, payloadMobility))
+									{
+										bShadowPayloadComplete[passIndex][payloadIndex] = false;
+									}
+									continue;
+								}
+
+								ShadowPrepassNode::PerInstanceData data;
+								data.model = meshWorldMatrix;
+								data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+								data.materialInstance = materialInstance;
+								data.skeletonOffset =
+									bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+								data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+								data.baseColorAlpha = baseColorAlpha;
+								data.baseColorSampler = baseColorSampler;
+								data.alphaCutoff = alphaCutoff;
+
+								viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
+							}
+						}
+					}
+				}
+				auto finalize = Tasks::CreateTask("Finalize shadow packet",
+					[view = submissionResources->m_activeShadowViews[passIndex]]()
+					{
+						SAILOR_PROFILE_SCOPE("Finalize shadow packet");
+						view->m_packet.Finalize(false);
+					}, EThreadType::Worker);
+				finalizeTasks.Add(finalize);
+				finalize->Run();
+			}
+
+			// Each worker owns one view packet. Cache publication and completion tokens
+			// stay on the coordinator, after every packet has retained its material versions.
+			for (const auto& task : finalizeTasks)
+			{
+				task->Wait();
+			}
+			for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
+			{
+				const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
+				const auto& viewResources = *submissionResources->m_activeShadowViews[passIndex];
+				auto& packet = submissionResources->m_activeShadowViews[passIndex]->m_packet;
+				bool bPassPayloadComplete = true;
+				for (bool bPayloadComplete : bShadowPayloadComplete[passIndex])
+				{
+					bPassPayloadComplete &= bPayloadComplete;
+				}
+				if (shadowPass.m_payloadCompletionToken)
+				{
+					shadowPass.m_payloadCompletionToken->Complete(
+						bPassPayloadComplete);
+				}
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					if (usesPagedArena(index))
+					{
+						continue;
+					}
+					if (bVirtualizeInstancePayloads &&
+						bBuildShadowPayloads[passIndex][index] &&
+						bShadowPayloadComplete[passIndex][index])
+					{
+						m_packetPayloadCache.Publish(
+							buildPayloadCacheSlot(
+								viewResources.m_viewKey,
+								shadowPass.m_shadowType,
+								mobility),
+							shadowPayloadRevisions[passIndex][index],
+							packet.SharePayload(mobility),
+							sceneView.m_frame);
+					}
+				}
+			}
+			m_pagedArenaCache.Evict(sceneView.m_frame);
+			m_syncSharedResources.Unlock();
+		}, EThreadType::RHI);
+}
+
 void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -172,8 +892,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	{
 		return;
 	}
-	const uint64_t materialSubmissionId =
-		sceneView.m_submissionContext->GetSubmissionId();
 
 	auto submissionResources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
 		this,
@@ -186,10 +904,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-	std::string virtualizeInstancePayloadsSetting;
-	const bool bVirtualizeInstancePayloads =
-		!TryGetString("VirtualizeInstancePayloads", virtualizeInstancePayloadsSetting) ||
-		virtualizeInstancePayloadsSetting != "false";
 
 	if (!m_pBlurVerticalShader)
 	{
@@ -304,678 +1018,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	commands->BeginDebugRegion(commandList, std::string(GetName()), DebugContext::Color_CmdGraphics);
 	{
 		const uint32_t NumShadowPasses = (uint32_t)sceneView.m_shadowMapsToUpdate.Num();
-		const size_t opaqueQueueTag = "Opaque"_h.GetHash();
-		const size_t maskedQueueTag = "Masked"_h.GetHash();
-		const size_t staticPayloadIndex =
-			RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
-				EMobilityType::Static);
-		const size_t stationaryPayloadIndex =
-			RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
-				EMobilityType::Stationary);
-		const bool bUsesPagedArenas = bVirtualizeInstancePayloads;
-		auto usesPagedArena = [&](size_t payloadIndex)
-			{
-				return bUsesPagedArenas &&
-					(payloadIndex == staticPayloadIndex ||
-						payloadIndex == stationaryPayloadIndex);
-			};
-		auto buildPayloadCacheSlot = [&](
-			uint64_t viewKey,
-			EShadowType shadowType,
-			EMobilityType mobility)
-			{
-				const size_t index =
-					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-				size_t cacheSlot = usesPagedArena(index) ?
-					Fnv1aOffsetBasis : viewKey;
-				if (usesPagedArena(index))
-				{
-					HashCombine(cacheSlot, static_cast<uint32_t>(shadowType), index);
-				}
-				else
-				{
-					HashCombine(cacheSlot, sceneView.m_cameraIndex, index);
-				}
-				return cacheSlot;
-			};
-		submissionResources->m_activeShadowViews.Clear(false);
-		submissionResources->m_activeShadowViews.Reserve(NumShadowPasses);
-		submissionResources->m_numActiveShadowViews = NumShadowPasses;
-		auto& shadowPayloadRevisions = submissionResources->m_shadowPayloadRevisions;
-		auto& bBuildShadowPayloads = submissionResources->m_buildShadowPayloads;
-		auto& bShadowPayloadComplete = submissionResources->m_shadowPayloadComplete;
-		shadowPayloadRevisions.Clear(false);
-		bBuildShadowPayloads.Clear(false);
-		bShadowPayloadComplete.Clear(false);
-		shadowPayloadRevisions.Resize(NumShadowPasses);
-		bBuildShadowPayloads.Resize(NumShadowPasses);
-		bShadowPayloadComplete.Resize(NumShadowPasses);
-		for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
-		{
-			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
-			size_t viewKey = Fnv1aOffsetBasis;
-			HashCombine(
-				viewKey,
-				shadowPass.m_lighMatrixIndex,
-				static_cast<uint32_t>(shadowPass.m_shadowType));
-			auto& viewResources = submissionResources->m_shadowViewCache[viewKey];
-			if (!viewResources)
-			{
-				viewResources = TSharedPtr<SubmissionResources::ShadowViewResources>::Make();
-			}
-			viewResources->Begin(viewKey);
-			submissionResources->m_activeShadowViews.Add(viewResources);
-
-			for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
-			{
-				auto& revision = shadowPayloadRevisions[passIndex][index];
-				revision = Fnv1aOffsetBasis;
-				HashCombine(
-					revision,
-					index,
-					shadowPass.m_lighMatrixIndex,
-					static_cast<uint32_t>(shadowPass.m_shadowType),
-					std::hash<glm::mat4>{}(shadowPass.m_lightMatrix),
-					std::hash<glm::vec3>{}(glm::vec3(sceneView.m_cameraTransform.m_position)));
-				bBuildShadowPayloads[passIndex][index] = true;
-				bShadowPayloadComplete[passIndex][index] = true;
-			}
-			if (bUsesPagedArenas)
-			{
-				for (const EMobilityType mobility :
-					{ EMobilityType::Static, EMobilityType::Stationary })
-				{
-					const size_t payloadIndex =
-						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-					auto& arenaRevision =
-						shadowPayloadRevisions[passIndex][payloadIndex];
-					arenaRevision = Fnv1aOffsetBasis;
-					HashCombine(
-						arenaRevision,
-						payloadIndex,
-						static_cast<uint32_t>(shadowPass.m_shadowType),
-						sceneView.m_submissionContext->GetMaterialRevision(),
-						sceneView.GetMobilityRevision(mobility));
-				}
-			}
-
-			if (bVirtualizeInstancePayloads)
-			{
-				for (const EMobilityType mobility :
-					{ EMobilityType::Static, EMobilityType::Stationary })
-				{
-					const size_t index =
-						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-					const size_t cacheSlot = buildPayloadCacheSlot(
-						viewKey,
-						shadowPass.m_shadowType,
-						mobility);
-					auto payload = usesPagedArena(index) ?
-						m_pagedArenaCache.Find(
-							cacheSlot,
-							shadowPayloadRevisions[passIndex][index],
-							sceneView.m_frame) :
-						m_packetPayloadCache.Find(
-							cacheSlot,
-							shadowPayloadRevisions[passIndex][index],
-							sceneView.m_frame);
-					if (payload)
-					{
-						if (usesPagedArena(index))
-						{
-							viewResources->m_packet.UseSharedArenaPayload(
-								mobility,
-								std::move(payload));
-						}
-						else
-						{
-							viewResources->m_packet.UseSharedPayload(
-								mobility,
-								std::move(payload));
-						}
-						bBuildShadowPayloads[passIndex][index] = false;
-					}
-				}
-			}
-		}
-
-		Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneView.m_frame);
-		m_packetPayloadCache.Evict(sceneView.m_frame);
-
-		SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
-
-		for (uint32_t passIndex = 0; passIndex < sceneView.m_shadowMapsToUpdate.Num(); passIndex++)
-		{
-			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
-			auto& viewResources =
-				*submissionResources->m_activeShadowViews[passIndex];
-			if (bUsesPagedArenas)
-			{
-				for (const EMobilityType mobility : {EMobilityType::Static, EMobilityType::Stationary})
-				{
-					const size_t arenaPayloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-					if (!bBuildShadowPayloads[passIndex][arenaPayloadIndex])
-					{
-						continue;
-					}
-					const size_t arenaCacheSlot =
-						buildPayloadCacheSlot(viewResources.m_viewKey, shadowPass.m_shadowType, mobility);
-					if (auto payload = m_pagedArenaCache.Find(
-							arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame))
-					{
-						viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(payload));
-						bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
-					}
-					else
-					{
-						m_pagedArenaCache.BeginUpdate(
-							arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame);
-						auto& rangeInstances = submissionResources->m_arenaRangeInstances;
-						auto& rangeStableKeys = submissionResources->m_arenaRangeStableKeys;
-						auto& rangeMaterialVersionRuns = submissionResources->m_arenaRangeMaterialVersionRuns;
-						sceneView.ForEachShadowCaster(mobility,
-							[&](const RHIVisibleShadowCaster& proxy)
-							{
-								const auto* source = proxy.GetSource();
-								if (!source || !proxy.m_resource)
-								{
-									return;
-								}
-								const uint64_t rangeKey =
-									BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource);
-								size_t rangeRevision = proxy.m_resource->m_shadowRevision;
-								HashCombine(rangeRevision, static_cast<uint32_t>(shadowPass.m_shadowType),
-									proxy.GetContentRevision(), std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
-									proxy.GetSkeletonOffset());
-								if (proxy.m_record)
-								{
-									HashCombine(rangeRevision, proxy.m_record->m_materialRevision,
-										proxy.m_record->m_shadowRevision, proxy.m_record->m_renderFlags);
-								}
-								for (const auto& shadowMesh : source->m_meshes)
-								{
-									if (shadowMesh.m_customDepthMaterial)
-									{
-										const auto materialVersion =
-											shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
-												materialSubmissionId);
-										HashCombine(
-											rangeRevision, materialVersion ? materialVersion->GetVersionId() : 0ull);
-									}
-								}
-								for (const auto& group : proxy.m_resource->m_proxy.m_instancedGroups)
-								{
-									for (const auto& material : group.m_materials)
-									{
-										if (material && material->GetRenderState().IsRequiredCustomDepthShader())
-										{
-											const auto materialVersion =
-												material->GetVersionForSubmission(materialSubmissionId);
-											HashCombine(rangeRevision,
-												materialVersion ? materialVersion->GetVersionId() : 0ull);
-										}
-									}
-								}
-								if (m_pagedArenaCache.TryReuseRange(rangeKey, rangeRevision))
-								{
-									return;
-								}
-								rangeInstances.Clear(false);
-								rangeStableKeys.Clear(false);
-								rangeMaterialVersionRuns.Clear(false);
-
-								auto addArenaShadowInstance =
-									[&](const RHIMeshPtr& mesh, const glm::mat4& model, size_t renderQueueTag,
-										float baseColorAlpha, uint32_t baseColorSampler, float alphaCutoff,
-										const ShaderSetPtr& customDepthShader,
-										const RHIMaterialPtr& customDepthMaterial,
-										const RHIMaterialVersionPtr& customDepthMaterialVersion, uint64_t stableKey)
-								{
-									if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
-									{
-										return;
-									}
-									if (!mesh)
-									{
-										bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
-										return;
-									}
-
-									const bool bSkinned =
-										proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
-										mesh->m_vertexDescription->HasAttribute(
-											RHIVertexDescription::DefaultBoneIdsBinding) &&
-										mesh->m_vertexDescription->HasAttribute(
-											RHIVertexDescription::DefaultBoneWeightsBinding);
-									const bool bMasked = renderQueueTag == maskedQueueTag;
-									auto depthMaterial = GetOrAddShadowMaterial(
-										mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
-									if (customDepthMaterial)
-									{
-										if (auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
-												customDepthMaterial, customDepthMaterialVersion,
-												mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked))
-										{
-											depthMaterial = customShadowMaterial;
-										}
-									}
-									if (!depthMaterial || !depthMaterial->GetVertexShader() ||
-										!depthMaterial->GetFragmentShader())
-									{
-										bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
-										return;
-									}
-
-									// Shadow materials are immutable derivatives of the exact source
-									// version resolved for this submission.
-									RHIBatch batch(depthMaterial, mesh);
-									const auto materialBindings = batch.GetMaterialBindings();
-									PerInstanceData data;
-									data.model = model;
-									data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-									data.materialInstance =
-										materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
-									data.skeletonOffset =
-										bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
-									data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
-									data.baseColorAlpha = baseColorAlpha;
-									data.baseColorSampler = baseColorSampler;
-									data.alphaCutoff = alphaCutoff;
-									rangeInstances.Add(std::move(data));
-									rangeStableKeys.Add(stableKey);
-									AppendPackedDrawArenaMaterialVersion(
-										rangeMaterialVersionRuns, batch.m_materialVersion);
-								};
-
-								for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num();
-									++shadowMeshIndex)
-								{
-									const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
-									addArenaShadowInstance(shadowMesh.m_mesh, proxy.ResolveMeshWorldMatrix(shadowMesh),
-										shadowMesh.m_renderQueueTag, shadowMesh.m_baseColorFactor.a,
-										shadowMesh.m_baseColorSampler, shadowMesh.m_alphaCutoff,
-										shadowMesh.m_customDepthShader, shadowMesh.m_customDepthMaterial,
-										shadowMesh.m_customDepthMaterial
-											? shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
-												  materialSubmissionId)
-											: RHIMaterialVersionPtr{},
-										BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(), 0u,
-											static_cast<uint32_t>(shadowMeshIndex), 0u));
-								}
-
-								const auto& topology = proxy.m_resource->m_proxy;
-								for (size_t groupIndex = 0u; groupIndex < topology.m_instancedGroups.Num();
-									++groupIndex)
-								{
-									const auto& group = topology.m_instancedGroups[groupIndex];
-									if (!group.m_bCastShadows)
-									{
-										continue;
-									}
-									for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
-									{
-										const size_t renderQueueTag = meshIndex < group.m_renderQueueTags.Num()
-											? group.m_renderQueueTags[meshIndex]
-											: 0u;
-										ShaderSetPtr customDepthShader;
-										RHIMaterialPtr customDepthMaterial;
-										if (meshIndex < group.m_sourceMaterialShaders.Num() &&
-											group.m_sourceMaterialShaders[meshIndex] &&
-											meshIndex < group.m_materials.Num() && group.m_materials[meshIndex] &&
-											group.m_materials[meshIndex]
-												->GetRenderState()
-												.IsRequiredCustomDepthShader())
-										{
-											customDepthShader = group.m_sourceMaterialShaders[meshIndex];
-											customDepthMaterial = group.m_materials[meshIndex];
-										}
-										for (size_t instanceIndex = 0u;
-											instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
-										{
-											addArenaShadowInstance(group.m_meshes[meshIndex],
-												proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex),
-												renderQueueTag,
-												meshIndex < group.m_baseColorFactors.Num()
-													? group.m_baseColorFactors[meshIndex].a
-													: 1.0f,
-												meshIndex < group.m_baseColorSamplers.Num()
-													? group.m_baseColorSamplers[meshIndex]
-													: 0u,
-												meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex]
-																					   : 0.5f,
-												customDepthShader, customDepthMaterial,
-												customDepthMaterial
-													? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
-													: RHIMaterialVersionPtr{},
-												BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
-													static_cast<uint32_t>(groupIndex + 1u),
-													static_cast<uint32_t>(meshIndex),
-													static_cast<uint32_t>(instanceIndex)));
-										}
-									}
-								}
-								if (!m_pagedArenaCache.ReplaceRange(rangeKey, rangeRevision, rangeInstances,
-										rangeStableKeys, &rangeMaterialVersionRuns))
-								{
-									bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
-								}
-							});
-
-						auto arenaPayload =
-							m_pagedArenaCache.EndUpdate(bShadowPayloadComplete[passIndex][arenaPayloadIndex]);
-						viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(arenaPayload));
-						rangeInstances.Clear(false);
-						rangeStableKeys.Clear(false);
-						rangeMaterialVersionRuns.Clear(false);
-						bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
-					}
-				}
-			}
-			for (const auto& proxy : shadowPass.m_meshList)
-			{
-				const auto* source = proxy.GetSource();
-				if (!source)
-				{
-					continue;
-				}
-				const EMobilityType payloadMobility = proxy.GetMobility();
-				const size_t payloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
-				if (!bBuildShadowPayloads[passIndex][payloadIndex] && !usesPagedArena(payloadIndex))
-				{
-					continue;
-				}
-
-				for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num(); ++shadowMeshIndex)
-				{
-					const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
-					const auto& mesh = sceneView.ResolveMesh(proxy, shadowMeshIndex);
-					if (!mesh)
-					{
-						if (shadowMesh.m_renderQueueTag == opaqueQueueTag ||
-							shadowMesh.m_renderQueueTag == maskedQueueTag)
-						{
-							bShadowPayloadComplete[passIndex][payloadIndex] = false;
-						}
-						continue;
-					}
-					const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(shadowMesh);
-
-					if (shadowMesh.m_maxCameraDistance < (std::numeric_limits<float>::max)())
-					{
-						Math::AABB worldBounds = mesh->m_bounds;
-						worldBounds.Apply(meshWorldMatrix);
-						const glm::vec3 cameraPosition(sceneView.m_cameraTransform.m_position);
-						const glm::vec3 closestPoint = glm::clamp(cameraPosition, worldBounds.m_min, worldBounds.m_max);
-						if (glm::distance(cameraPosition, closestPoint) > shadowMesh.m_maxCameraDistance)
-						{
-							continue;
-						}
-					}
-					const size_t renderQueueTag = shadowMesh.m_renderQueueTag;
-					if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
-					{
-						continue;
-					}
-
-					const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
-						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
-						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
-					const bool bMasked = renderQueueTag == maskedQueueTag;
-					auto depthMaterial =
-						GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
-					if (shadowMesh.m_customDepthMaterial)
-					{
-						auto customShadowMaterial = GetOrAddCustomShadowMaterial(shadowMesh.m_customDepthShader,
-							shadowMesh.m_customDepthMaterial,
-							shadowMesh.m_customDepthMaterial->GetVersionForSubmission(materialSubmissionId),
-							mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
-						if (customShadowMaterial)
-						{
-							depthMaterial = customShadowMaterial;
-						}
-					}
-
-					const bool bIsDepthMaterialReady =
-						depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
-
-					if (!bIsDepthMaterialReady)
-					{
-						bShadowPayloadComplete[passIndex][payloadIndex] = false;
-						continue;
-					}
-					RHIBatch batch(depthMaterial, mesh);
-
-					ShadowPrepassNode::PerInstanceData data;
-					data.model = meshWorldMatrix;
-					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-					const auto materialBindings = batch.GetMaterialBindings();
-					data.materialInstance =
-						materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
-					data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
-					data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
-					data.baseColorAlpha = shadowMesh.m_baseColorFactor.a;
-					data.baseColorSampler = shadowMesh.m_baseColorSampler;
-					data.alphaCutoff = shadowMesh.m_alphaCutoff;
-
-					if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
-					{
-						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
-#if defined(__APPLE__)
-						batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(m_textureBindingCache,
-							shadowMesh.m_materialTextureSamplers, sceneView.m_frame, supportedMeshesPerBatch);
-#else
-						batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
-#endif
-						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
-						if (!batch.m_textureBindings)
-						{
-							bShadowPayloadComplete[passIndex][payloadIndex] = false;
-							continue;
-						}
-					}
-					const uint64_t stableKey = BuildPackedDrawStableKey(
-						proxy.m_handle, proxy.GetProducerKey(), 0u, static_cast<uint32_t>(shadowMeshIndex), 0u);
-					if (usesPagedArena(payloadIndex))
-					{
-						if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
-								BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
-								stableKey, payloadMobility))
-						{
-							bShadowPayloadComplete[passIndex][payloadIndex] = false;
-						}
-						continue;
-					}
-
-					viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
-				}
-
-				const auto* topology = proxy.m_resource ? &proxy.m_resource->m_proxy : nullptr;
-				if (!topology)
-				{
-					continue;
-				}
-
-				for (size_t groupIndex = 0u; groupIndex < topology->m_instancedGroups.Num(); ++groupIndex)
-				{
-					const auto& group = topology->m_instancedGroups[groupIndex];
-					if (!group.m_bCastShadows)
-					{
-						continue;
-					}
-
-					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
-					{
-						const size_t renderQueueTag =
-							meshIndex < group.m_renderQueueTags.Num() ? group.m_renderQueueTags[meshIndex] : 0u;
-						if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
-						{
-							continue;
-						}
-
-						const auto& sourceMesh = group.m_meshes[meshIndex];
-						if (!sourceMesh)
-						{
-							bShadowPayloadComplete[passIndex][payloadIndex] = false;
-							continue;
-						}
-
-						const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
-							sourceMesh->m_vertexDescription->HasAttribute(
-								RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
-							sourceMesh->m_vertexDescription->HasAttribute(
-								RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
-						const bool bMasked = renderQueueTag == maskedQueueTag;
-						auto depthMaterial = GetOrAddShadowMaterial(
-							sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
-
-						ShaderSetPtr customDepthShader;
-						RHIMaterialPtr customDepthMaterial;
-						if (meshIndex < group.m_sourceMaterialShaders.Num() &&
-							group.m_sourceMaterialShaders[meshIndex] && meshIndex < group.m_materials.Num() &&
-							group.m_materials[meshIndex] &&
-							group.m_materials[meshIndex]->GetRenderState().IsRequiredCustomDepthShader())
-						{
-							customDepthShader = group.m_sourceMaterialShaders[meshIndex];
-							customDepthMaterial = group.m_materials[meshIndex];
-							auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
-								customDepthMaterial,
-								customDepthMaterial ? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
-													: RHIMaterialVersionPtr{},
-								sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
-							if (customShadowMaterial)
-							{
-								depthMaterial = customShadowMaterial;
-							}
-						}
-
-						const bool bIsDepthMaterialReady =
-							depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
-						if (!bIsDepthMaterialReady)
-						{
-							bShadowPayloadComplete[passIndex][payloadIndex] = false;
-							continue;
-						}
-
-						RHIBatch batchTemplate(depthMaterial, sourceMesh);
-						const auto materialBindings = batchTemplate.GetMaterialBindings();
-						const uint32_t materialInstance =
-							materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
-						if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
-						{
-							uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
-#if defined(__APPLE__)
-							const auto& requestedTextures = meshIndex < group.m_materialTextureSamplers.Num()
-								? group.m_materialTextureSamplers[meshIndex]
-								: Framegraph::Details::GetDefaultRequestedTextures();
-							batchTemplate.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
-								m_textureBindingCache, requestedTextures, sceneView.m_frame, supportedMeshesPerBatch);
-#else
-							batchTemplate.m_textureBindings =
-								App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
-#endif
-							batchTemplate.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
-							if (!batchTemplate.m_textureBindings)
-							{
-								bShadowPayloadComplete[passIndex][payloadIndex] = false;
-								continue;
-							}
-						}
-
-						const float baseColorAlpha = meshIndex < group.m_baseColorFactors.Num()
-							? group.m_baseColorFactors[meshIndex].a
-							: 1.0f;
-						const uint32_t baseColorSampler =
-							meshIndex < group.m_baseColorSamplers.Num() ? group.m_baseColorSamplers[meshIndex] : 0u;
-						const float alphaCutoff =
-							meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex] : 0.5f;
-
-						for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
-							++instanceIndex)
-						{
-							if (!proxy.IsInstancedMeshWithinDistance(group, instanceIndex, meshIndex,
-									glm::vec3(sceneView.m_cameraTransform.m_position), group.m_maxShadowDistance))
-							{
-								continue;
-							}
-							const auto& mesh =
-								sceneView.ResolveInstancedMesh(proxy, groupIndex, instanceIndex, meshIndex);
-							if (!mesh)
-							{
-								bShadowPayloadComplete[passIndex][payloadIndex] = false;
-								continue;
-							}
-							const uint64_t stableKey = BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
-								static_cast<uint32_t>(groupIndex + 1u), static_cast<uint32_t>(meshIndex),
-								static_cast<uint32_t>(instanceIndex));
-							const glm::mat4 meshWorldMatrix =
-								proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex);
-							RHIBatch batch = batchTemplate;
-							batch.m_mesh = mesh;
-							if (usesPagedArena(payloadIndex))
-							{
-								if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
-										BuildPackedDrawRangeKey(
-											proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
-										stableKey, payloadMobility))
-								{
-									bShadowPayloadComplete[passIndex][payloadIndex] = false;
-								}
-								continue;
-							}
-
-							ShadowPrepassNode::PerInstanceData data;
-							data.model = meshWorldMatrix;
-							data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-							data.materialInstance = materialInstance;
-							data.skeletonOffset =
-								bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
-							data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
-							data.baseColorAlpha = baseColorAlpha;
-							data.baseColorSampler = baseColorSampler;
-							data.alphaCutoff = alphaCutoff;
-
-							viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
-						}
-					}
-				}
-			}
-			auto& packet = submissionResources->m_activeShadowViews[passIndex]->m_packet;
-			packet.Finalize(false);
-			bool bPassPayloadComplete = true;
-			for (bool bPayloadComplete : bShadowPayloadComplete[passIndex])
-			{
-				bPassPayloadComplete &= bPayloadComplete;
-			}
-			if (shadowPass.m_payloadCompletionToken)
-			{
-				shadowPass.m_payloadCompletionToken->Complete(
-					bPassPayloadComplete);
-			}
-			for (const EMobilityType mobility :
-				{ EMobilityType::Static, EMobilityType::Stationary })
-			{
-				const size_t index =
-					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-				if (usesPagedArena(index))
-				{
-					continue;
-				}
-				if (bVirtualizeInstancePayloads &&
-					bBuildShadowPayloads[passIndex][index] &&
-					bShadowPayloadComplete[passIndex][index])
-				{
-					m_packetPayloadCache.Publish(
-						buildPayloadCacheSlot(
-							viewResources.m_viewKey,
-							shadowPass.m_shadowType,
-							mobility),
-						shadowPayloadRevisions[passIndex][index],
-						packet.SharePayload(mobility),
-						sceneView.m_frame);
-				}
-			}
-		}
-		m_pagedArenaCache.Evict(sceneView.m_frame);
 
 		for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
 		{

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Core/Defines.h"
+#include "Core/SpinLock.h"
 #include "Memory/RefPtr.hpp"
 #include "Engine/Object.h"
 #include "RHI/Types.h"
@@ -55,6 +56,7 @@ namespace Sailor
 			return shadowType == RHI::EShadowType::PCF ? -configuredBias : 0.0f;
 		}
 
+		SAILOR_API virtual Tasks::TaskPtr<void, void> Prepare(RHI::RHIFrameGraphPtr frameGraph, const RHI::RHISceneViewSnapshot& sceneView) override;
 		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandLists, const RHI::RHISceneViewSnapshot& sceneView) override;
 		SAILOR_API virtual void Clear() override;
 
@@ -173,6 +175,7 @@ namespace Sailor
 		Framegraph::TextureBindingCache m_textureBindingCache{};
 		RHI::TPackedDrawPacketPayloadCache<PerInstanceData> m_packetPayloadCache{};
 		RHI::TPackedDrawPagedArenaCache<PerInstanceData> m_pagedArenaCache{};
+		SpinLock m_syncSharedResources{};
 
 		SAILOR_SHARED_API static const char* m_name;
 	};

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -916,16 +916,22 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 				{
 					SAILOR_PROFILE_SCOPE("Clear after Present");
 
-					rhiSceneView->Clear();
-
-					auto& list = m_cachedSceneViews.At_Lock(rhiSceneView->m_world);
-					auto it = list.FindIf([&](const auto& el) { return el.m_first == rhiSceneView; });
-					if (it != list.end())
 					{
-						(*it).m_second = true;
+						SAILOR_PROFILE_SCOPE("Clear submitted scene view");
+						rhiSceneView->Clear();
 					}
 
-					m_cachedSceneViews.Unlock(rhiSceneView->m_world);
+					{
+						SAILOR_PROFILE_SCOPE("Return scene view to cache");
+						auto& list = m_cachedSceneViews.At_Lock(rhiSceneView->m_world);
+						auto it = list.FindIf([&](const auto& el) { return el.m_first == rhiSceneView; });
+						if (it != list.end())
+						{
+							(*it).m_second = true;
+						}
+
+						m_cachedSceneViews.Unlock(rhiSceneView->m_world);
+					}
 
 					GetDriver()->CollectGarbage_RenderThread();
 				}

--- a/Runtime/RHI/Scene.cpp
+++ b/Runtime/RHI/Scene.cpp
@@ -456,17 +456,37 @@ bool RHIScene::UpdateInstance(
 	const RHISceneInstanceRecord& record,
 	SceneChangeMask changeMask)
 {
-	if (changeMask == ToMask(ESceneChangeBit::None))
-	{
-		return true;
-	}
-
 	m_lock.Lock();
+	const bool updated = UpdateInstanceLocked(handle, record, changeMask);
+	m_lock.Unlock();
+	return updated;
+}
+
+size_t RHIScene::UpdateInstances(const TVector<RHISceneInstanceUpdate>& updates)
+{
+	SAILOR_PROFILE_FUNCTION();
+	m_lock.Lock();
+	size_t numUpdated = 0u;
+	for (const auto& update : updates)
+	{
+		numUpdated += UpdateInstanceLocked(update.m_handle, update.m_record, update.m_changeMask) ? 1u : 0u;
+	}
+	m_lock.Unlock();
+	return numUpdated;
+}
+
+bool RHIScene::UpdateInstanceLocked(RenderInstanceHandle handle,
+	const RHISceneInstanceRecord& record, SceneChangeMask changeMask)
+{
 	LogicalSlot* slot = nullptr;
 	if (!ResolveSlot(handle, slot))
 	{
-		m_lock.Unlock();
 		return false;
+	}
+
+	if (changeMask == ToMask(ESceneChangeBit::None))
+	{
+		return true;
 	}
 
 	const EMobilityType oldMobility = slot->m_record.m_mobility;
@@ -482,7 +502,6 @@ bool RHIScene::UpdateInstance(
 	{
 		m_bHandleListsDirty = true;
 	}
-	m_lock.Unlock();
 	return true;
 }
 

--- a/Runtime/RHI/Scene.h
+++ b/Runtime/RHI/Scene.h
@@ -248,6 +248,13 @@ namespace Sailor::RHI
 		uint32_t m_nextOffset = 0u;
 	};
 
+	struct RHISceneInstanceUpdate
+	{
+		RenderInstanceHandle m_handle{};
+		RHISceneInstanceRecord m_record{};
+		SceneChangeMask m_changeMask = ToMask(ESceneChangeBit::None);
+	};
+
 	class RHIScene final : public RHIResource
 	{
 	public:
@@ -260,6 +267,9 @@ namespace Sailor::RHI
 			const RHISceneInstanceRecord& record,
 			SceneChangeMask changeMask);
 		SAILOR_SHARED_API bool RemoveInstance(RenderInstanceHandle handle);
+		// Commit prepared records under one lock. Stale handles are skipped;
+		// the result counts valid updates, including valid no-op updates.
+		SAILOR_SHARED_API size_t UpdateInstances(const TVector<RHISceneInstanceUpdate>& updates);
 		SAILOR_SHARED_API bool ResolveCurrent(
 			RenderInstanceHandle handle,
 			RHISceneInstanceRecord& outRecord) const;
@@ -290,6 +300,8 @@ namespace Sailor::RHI
 		bool ResolveSlot(RenderInstanceHandle handle, LogicalSlot*& outSlot);
 		bool ResolveSlot(RenderInstanceHandle handle, const LogicalSlot*& outSlot) const;
 		void AppendChange(RenderInstanceHandle handle, SceneChangeMask mask);
+		bool UpdateInstanceLocked(RenderInstanceHandle handle,
+			const RHISceneInstanceRecord& record, SceneChangeMask changeMask);
 		void BumpMobilityRevision(EMobilityType mobility);
 		void RebuildHandleLists(RHISceneVersion& version);
 		RHISceneRecordRootPtr BuildRecordRoot();

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -781,15 +781,21 @@ void RHISceneView::Clear()
 
 	m_drawImGui.Clear();
 	m_debugDraw.Clear(false);
-	for (auto& snapshot : m_snapshots)
 	{
-		snapshot.ResetForReuse();
+		SAILOR_PROFILE_SCOPE("Reset submitted view snapshots");
+		for (auto& snapshot : m_snapshots)
+		{
+			snapshot.ResetForReuse();
+		}
 	}
 	m_submissionContext.Clear();
 	m_submissionCompletionToken.Clear();
-	m_sceneVersions.Clear(false);
-	m_virtualSceneVersions.Clear(false);
-	m_retainedSceneVersions.Clear();
+	{
+		SAILOR_PROFILE_SCOPE("Release submitted scene versions");
+		m_sceneVersions.Clear(false);
+		m_virtualSceneVersions.Clear(false);
+		m_retainedSceneVersions.Clear();
+	}
 	m_sceneRevision = 0ull;
 	m_renderMode = ESceneViewRenderMode::Lit;
 	m_shadowCastersRevision = 0ull;
@@ -802,6 +808,7 @@ void RHISceneView::Clear()
 
 void RHISceneViewSnapshot::ResetForReuse()
 {
+	SAILOR_PROFILE_FUNCTION();
 	m_submissionContext.Clear();
 	m_previousMotionFrame.Clear();
 	m_sceneVersions.Clear();
@@ -811,9 +818,12 @@ void RHISceneViewSnapshot::ResetForReuse()
 	m_frame = 0ull;
 	m_cameraIndex = 0u;
 	m_cameraTransform = {};
-	m_proxies.Clear(false);
-	m_lodMeshes.Clear(false);
-	m_instancedLodOffsets.Clear(false);
+	{
+		SAILOR_PROFILE_SCOPE("Release visible proxies and LOD meshes");
+		m_proxies.Clear(false);
+		m_lodMeshes.Clear(false);
+		m_instancedLodOffsets.Clear(false);
+	}
 	m_pathTracerProxies.Clear(false);
 	m_pathTracerTLASInstances.Clear(false);
 	m_pathTracerMaterials.Clear(false);

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -239,11 +239,65 @@ namespace Sailor::RHI
 	 * Immutable after publication. ECS producers rebuild this adapter only when
 	 * their scene data changes; render views retain and share it across submissions.
 	 */
+	class RHISceneSpatialIndex
+	{
+	public:
+		RHISceneSpatialIndex(glm::ivec3 center, uint32_t size, uint32_t minSize,
+			size_t numPartitions = 1u, size_t partitionCapacity = 64u) :
+			m_center(center), m_size(size), m_minSize(minSize), m_partitionCapacity(partitionCapacity)
+		{
+			m_partitions.Resize(numPartitions);
+		}
+
+		// Each partition has one writer during construction. Readers start only
+		// after all writers join; published indices are never modified.
+		bool Update(const glm::ivec3& center, const glm::ivec3& extents,
+			RenderInstanceHandle handle, size_t partitionIndex = 0u)
+		{
+			auto& partition = m_partitions[partitionIndex];
+			if (!partition)
+			{
+				partition = TSharedPtr<TOctree<RenderInstanceHandle>>::Make(
+					m_center, m_size, m_minSize, m_partitionCapacity);
+			}
+			return partition->Update(center, extents, handle);
+		}
+
+		size_t Num() const
+		{
+			size_t count = 0u;
+			for (const auto& partition : m_partitions)
+			{
+				count += partition ? partition->Num() : 0u;
+			}
+			return count;
+		}
+
+		template<typename TCallback>
+		void Trace(const Math::Frustum& frustum, TCallback&& callback) const
+		{
+			for (const auto& partition : m_partitions)
+			{
+				if (partition)
+				{
+					partition->Trace(frustum, callback);
+				}
+			}
+		}
+
+	private:
+		TVector<TSharedPtr<TOctree<RenderInstanceHandle>>> m_partitions{};
+		glm::ivec3 m_center{};
+		uint32_t m_size = 0u;
+		uint32_t m_minSize = 0u;
+		size_t m_partitionCapacity = 0u;
+	};
+
 	struct RHISpatialSceneVersion
 	{
-		TSharedPtr<TOctree<RenderInstanceHandle>> m_dynamicOctree{};
-		TSharedPtr<TOctree<RenderInstanceHandle>> m_stationaryOctree{};
-		TSharedPtr<TOctree<RenderInstanceHandle>> m_staticOctree{};
+		TSharedPtr<RHISceneSpatialIndex> m_dynamicOctree{};
+		TSharedPtr<RHISceneSpatialIndex> m_stationaryOctree{};
+		TSharedPtr<RHISceneSpatialIndex> m_staticOctree{};
 		uint64_t m_revision = 0ull;
 		uint64_t m_shadowCastersRevision = 0ull;
 		bool m_bHasCustomDepthShadowCasters = false;

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -176,6 +176,12 @@ namespace
 		uint32_t GetNextBoneOffsetForTest() const { return m_nextBoneOffset; }
 	};
 
+	class PublishedMeshTestSystem final : public StaticMeshRendererECS
+	{
+	public:
+		const RHI::RHISpatialSceneVersionPtr& GetSpatialVersion() const { return m_publishedSceneVersion; }
+	};
+
 	class PrefabTestWorld final : public World
 	{
 	public:
@@ -201,7 +207,7 @@ namespace
 		{
 			TVector<ECS::TBaseSystemPtr> systems;
 			systems.Add(TUniquePtr<TransformECS>::Make());
-			systems.Add(TUniquePtr<StaticMeshRendererECS>::Make());
+			systems.Add(TUniquePtr<PublishedMeshTestSystem>::Make());
 			return systems;
 		}
 	};
@@ -904,6 +910,70 @@ namespace
 		Require(meshes->GetRHIScene()->GetCurrentVersion()->m_staticHandles->IsEmpty(),
 			"unregistering the component must remove its published instance");
 		world.Clear();
+	}
+
+	void TestMeshBatchesWithSharedOwnerAndRegistrationHoles()
+	{
+		PrefabTestWorld world;
+		auto owner = world.Instantiate("MultipleMeshBatches");
+		owner->SetMobilityType(EMobilityType::Dynamic);
+		auto* meshes = world.GetECS<StaticMeshRendererECS>();
+		meshes->BeginPlay();
+		auto model = TObjectPtr<PublishedMeshTestModel>::Make(world.GetAllocator());
+		model->m_ready = true;
+		auto material = TObjectPtr<PublishedMeshTestMaterial>::Make(world.GetAllocator());
+		TVector<size_t> slots;
+		for (size_t i = 0u; i < 1031u; ++i)
+		{
+			const auto slot = meshes->RegisterComponent();
+			slots.Add(slot);
+			auto& data = meshes->GetComponentData(slot);
+			data.SetOwner(owner);
+			data.SetModel(model);
+			data.GetMaterials().Add(material);
+		}
+		meshes->Tick(0.016f);
+		auto before = meshes->GetRHIScene()->GetCurrentVersion();
+		Require(before->m_dynamicHandles->Num() == slots.Num(), "initial publication must include every component batch");
+		auto retainedView = RHI::RHISceneViewPtr::Make();
+		retainedView->AddSceneVersion(static_cast<PublishedMeshTestSystem*>(meshes)->GetSpatialVersion());
+		size_t removed = 0u;
+		for (size_t i = 0u; i < slots.Num(); i += 17u)
+		{
+			meshes->UnregisterComponent(slots[i]);
+			++removed;
+		}
+		world.AdvanceFrame();
+		owner->GetTransformComponent().SetPosition(glm::vec3(4.0f, 0.0f, 0.0f));
+		auto* transforms = world.GetECS<TransformECS>();
+		transforms->Tick(0.016f);
+		transforms->PostTick();
+		meshes->Tick(0.016f);
+		auto moved = meshes->GetRHIScene()->GetCurrentVersion();
+		Require(moved->m_dynamicHandles->Num() == slots.Num() - removed,
+			"registration holes and a partial last batch must preserve exactly the live instances");
+		auto currentView = RHI::RHISceneViewPtr::Make();
+		currentView->AddSceneVersion(static_cast<PublishedMeshTestSystem*>(meshes)->GetSpatialVersion());
+		Math::Frustum narrowView;
+		narrowView.ExtractFrustumPlanes(glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, 5.0f)),
+			1.0f, 20.0f, 0.1f, 10.0f);
+		Require(retainedView->TraceScene(narrowView, false).Num() == slots.Num() &&
+			currentView->TraceScene(narrowView, false).IsEmpty(),
+			"a delayed render view must retain its old spatial root after the world moves and removes instances");
+		for (const auto handle : *moved->m_dynamicHandles)
+		{
+			const RHI::RHISceneInstanceRecord* oldRecord = nullptr;
+			const RHI::RHISceneInstanceRecord* newRecord = nullptr;
+			Require(before->Resolve(handle, oldRecord) && moved->Resolve(handle, newRecord) &&
+				oldRecord->m_worldMatrix[3].x == 0.0f && newRecord->m_worldMatrix[3].x == 4.0f &&
+				oldRecord->m_topology == newRecord->m_topology,
+				"every batch must publish the new transform and retain immutable topology and old snapshots");
+		}
+		world.AdvanceFrame();
+		meshes->Tick(0.016f);
+		Require(meshes->GetRHIScene()->GetCurrentVersion() == moved,
+			"reused batch scratch must not replay old changes when the scene is unchanged");
+		meshes->EndPlay();
 	}
 
 	void TestClearingMeshModelAlsoClearsMaterials()
@@ -3846,6 +3916,7 @@ int main()
 		{ "EditorKeepWorldReparentRejectsShearedCandidateWithoutMutation", TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation },
 		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
 		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
+		{ "MeshBatchesWithSharedOwnerAndRegistrationHoles", TestMeshBatchesWithSharedOwnerAndRegistrationHoles },
 		{ "FrameZeroMeshPublicationStaysStable", TestFrameZeroMeshPublicationStaysStable },
 		{ "StaticMeshLodSelectionUsesScreenCoverage", TestStaticMeshLodSelectionUsesScreenCoverage },
 		{ "LocalLightShadowContract", TestLocalLightShadowContract },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -26,6 +26,11 @@
 #include "RHI/VertexDescription.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <thread>
+#include <vector>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -900,6 +905,110 @@ namespace
 			"ending an active submission must release material history that is no longer retained by a packet");
 	}
 
+	void TestMaterialVersionsSurviveConcurrentWorldUpdates()
+	{
+		auto material = RHI::RHIMaterialPtr::Make(RHI::RenderState{}, RHI::RHIShaderPtr{}, RHI::RHIShaderPtr{});
+		std::array<RHI::RHIMaterialVersionPtr, 3u> versions;
+		std::array<RHI::RHIShaderBindingSetPtr, 3u> bindings;
+		for (size_t frame = 0u; frame < versions.size(); ++frame)
+		{
+			bindings[frame] = RHI::RHIShaderBindingSetPtr::Make();
+			material->SetBindings(bindings[frame]);
+			versions[frame] = material->GetVersion();
+			RHI::RHIMaterial::BeginSubmissionVersionCapture(400ull + frame);
+		}
+		std::barrier sync(4);
+		std::atomic<bool> valid{ true };
+		std::vector<std::thread> renderWorkers;
+		for (size_t frame = 0u; frame < versions.size(); ++frame)
+		{
+			renderWorkers.emplace_back([&, frame]()
+				{
+					for (size_t nextFrame = 0u; nextFrame < 32u; ++nextFrame)
+					{
+						sync.arrive_and_wait();
+						// Simulate main, depth, and shadow packets prepared after
+						// the game thread has started publishing later materials.
+						for (size_t pass = 0u; pass < 3u; ++pass)
+						{
+							RHI::RHIBatch batch(material, {}, 400ull + frame);
+							if (batch.m_materialVersion != versions[frame] || batch.GetMaterialBindings() != bindings[frame])
+							{
+								valid.store(false);
+							}
+						}
+						sync.arrive_and_wait();
+					}
+				});
+		}
+		for (size_t nextFrame = 0u; nextFrame < 32u; ++nextFrame)
+		{
+			sync.arrive_and_wait();
+			material->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+			sync.arrive_and_wait();
+		}
+		for (auto& worker : renderWorkers)
+		{
+			worker.join();
+		}
+		for (size_t frame = 0u; frame < versions.size(); ++frame)
+		{
+			RHI::RHIMaterial::EndSubmissionVersionCapture(400ull + frame);
+		}
+		Require(valid.load(), "three in-flight frames must bind their saved material generations during concurrent publication");
+		for (size_t frame = 0u; frame < versions.size(); ++frame)
+		{
+			Require(versions[frame]->GetBindings() == bindings[frame],
+				"retained draw-packet versions must own their descriptors after the submission cutoff is released");
+		}
+	}
+
+	void TestParallelSpatialIndexVisibility()
+	{
+		constexpr size_t NumPartitions = 8u;
+		constexpr size_t NumElements = 768u;
+		const auto centerFor = [](size_t i)
+			{
+				return glm::ivec3(int(i % 32u) * 6 - 96, int(i % 5u) - 2, -int(i / 32u) * 8 - 4);
+			};
+		const auto extentsFor = [](size_t i) { return glm::ivec3(i % 11u == 0u ? 9 : 1); };
+		auto spatial = TSharedPtr<RHI::RHISceneSpatialIndex>::Make(glm::ivec3(0), 4096u, 4u, NumPartitions);
+		std::vector<std::thread> workers;
+		for (size_t partition = 0u; partition < NumPartitions; ++partition)
+		{
+			workers.emplace_back([&, partition]()
+				{
+					for (size_t i = partition; i < NumElements; i += NumPartitions)
+					{
+						spatial->Update(centerFor(i), extentsFor(i), { uint32_t(i), 1u }, partition);
+					}
+				});
+		}
+		for (auto& worker : workers)
+		{
+			worker.join();
+		}
+		Require(spatial->Num() == NumElements, "independent writers must preserve every spatial handle");
+		for (float cameraX : { -80.0f, 0.0f, 80.0f })
+		{
+			Math::Frustum frustum;
+			frustum.ExtractFrustumPlanes(glm::translate(glm::mat4(1.0f), glm::vec3(cameraX, 0.0f, 0.0f)),
+				1.0f, 60.0f, 0.1f, 150.0f);
+			std::vector<uint32_t> expected, visible;
+			for (size_t i = 0u; i < NumElements; ++i)
+			{
+				if (frustum.OverlapsAABB(Math::AABB(centerFor(i), extentsFor(i))))
+				{
+					expected.push_back(uint32_t(i));
+				}
+			}
+			spatial->Trace(frustum, [&](const RHI::RenderInstanceHandle& handle) { visible.push_back(handle.m_slot); });
+			std::sort(visible.begin(), visible.end());
+			Require(!expected.empty() && expected.size() < NumElements && visible == expected,
+				"partitioned culling must match brute-force bounds with no missing or duplicated handles");
+		}
+	}
+
 	void TestDynamicSpatialRootIsolation()
 	{
 		RHI::RHISceneViewProxy proxy;
@@ -923,7 +1032,7 @@ namespace
 		spatial->m_scene = scene;
 		spatial->m_sceneVersion = scene->PublishVersion();
 		spatial->m_dynamicOctree =
-			TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+			TSharedPtr<RHI::RHISceneSpatialIndex>::Make(
 				glm::ivec3(0), 128, 4);
 		Require(spatial->m_dynamicOctree->Update(
 			glm::ivec3(0, 0, -5),
@@ -1485,7 +1594,9 @@ int main()
 		{ "PackedDrawBatchInstanceLimit", TestPackedDrawBatchInstanceLimit },
 		{ "PackedDrawMixedMaterialSort", TestPackedDrawMixedMaterialSort },
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
+		{ "MaterialVersionsSurviveConcurrentWorldUpdates", TestMaterialVersionsSurviveConcurrentWorldUpdates },
 		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
+		{ "ParallelSpatialIndexVisibility", TestParallelSpatialIndexVisibility },
 		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },
 		{ "SnapshotCameraLodContract", TestSnapshotCameraLodContract },
 		{ "BatchTextureBindingIdentityContract", TestBatchTextureBindingIdentityContract },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -907,9 +907,11 @@ namespace
 
 	void TestMaterialVersionsSurviveConcurrentWorldUpdates()
 	{
+		constexpr uint32_t NumInstances = 64u;
 		auto material = RHI::RHIMaterialPtr::Make(RHI::RenderState{}, RHI::RHIShaderPtr{}, RHI::RHIShaderPtr{});
 		std::array<RHI::RHIMaterialVersionPtr, 3u> versions;
 		std::array<RHI::RHIShaderBindingSetPtr, 3u> bindings;
+		std::array<std::array<RHI::TPackedDrawPacket<uint32_t>, 3u>, 3u> packets;
 		for (size_t frame = 0u; frame < versions.size(); ++frame)
 		{
 			bindings[frame] = RHI::RHIShaderBindingSetPtr::Make();
@@ -931,10 +933,30 @@ namespace
 						// the game thread has started publishing later materials.
 						for (size_t pass = 0u; pass < 3u; ++pass)
 						{
-							RHI::RHIBatch batch(material, {}, 400ull + frame);
+							auto& packet = packets[frame][pass];
+							packet.Reset();
+							for (uint32_t index = 0u; index < NumInstances; ++index)
+							{
+								packet.Add(RHI::RHIBatch(material, {}, 400ull + frame), {},
+									NumInstances - index, NumInstances - index);
+							}
+							packet.Finalize(false);
+							if (packet.GetGroups().Num() != 1u || packet.GetNumDrawInstances() != NumInstances)
+							{
+								valid.store(false);
+								continue;
+							}
+							const auto& batch = packet.GetGroups()[0].m_batch;
 							if (batch.m_materialVersion != versions[frame] || batch.GetMaterialBindings() != bindings[frame])
 							{
 								valid.store(false);
+							}
+							for (uint32_t index = 0u; index < NumInstances; ++index)
+							{
+								if (packet.GetPayload(EMobilityType::Dynamic).m_instances[index] != index + 1u)
+								{
+									valid.store(false);
+								}
 							}
 						}
 						sync.arrive_and_wait();
@@ -958,8 +980,11 @@ namespace
 		Require(valid.load(), "three in-flight frames must bind their saved material generations during concurrent publication");
 		for (size_t frame = 0u; frame < versions.size(); ++frame)
 		{
-			Require(versions[frame]->GetBindings() == bindings[frame],
-				"retained draw-packet versions must own their descriptors after the submission cutoff is released");
+			for (const auto& packet : packets[frame])
+			{
+				Require(packet.GetGroups()[0].m_batch.GetMaterialBindings() == bindings[frame],
+					"finalized draw packets must own their descriptors after the submission cutoff is released");
+			}
 		}
 	}
 

--- a/Tests/RHISceneVirtualizationTests.cpp
+++ b/Tests/RHISceneVirtualizationTests.cpp
@@ -90,6 +90,58 @@ namespace
 			"collecting older versions must not invalidate a recycled live handle");
 	}
 
+	void TestBatchUpdatesPreserveVersionsAndFlightReplay()
+	{
+		auto scene = RHIScenePtr::Make(2u);
+		TVector<RenderInstanceHandle> handles;
+		for (size_t i = 0u; i < 150u; ++i)
+		{
+			handles.Add(scene->AddInstance(MakeRecord(i, EMobilityType::Dynamic, float(i))));
+		}
+		auto before = scene->PublishVersion();
+		scene->PrepareFlight(0u, before);
+		TVector<RHISceneInstanceUpdate> updates;
+		for (size_t i = 0u; i < handles.Num(); ++i)
+		{
+			const auto mobility = i % 3u == 0u ? EMobilityType::Stationary : EMobilityType::Dynamic;
+			updates.Add({ handles[i], MakeRecord(i, mobility, float(i + 1000u)),
+				ToMask(ESceneChangeBit::Transform) | ToMask(ESceneChangeBit::Bounds) |
+				ToMask(ESceneChangeBit::Mobility) });
+		}
+		const uint64_t revision = scene->GetRevision();
+		Require(scene->UpdateInstances(updates) == handles.Num(), "a batch must update every live handle");
+		Require(scene->GetRevision() == revision + handles.Num(), "each changed handle must retain its journal revision");
+		auto after = scene->PublishVersion();
+		Require(after->m_stationaryHandles->Num() == 50u && after->m_dynamicHandles->Num() == 100u,
+			"batch mobility changes must rebuild the published handle lists");
+		for (size_t i = 0u; i < handles.Num(); ++i)
+		{
+			const RHISceneInstanceRecord* oldRecord = nullptr;
+			const RHISceneInstanceRecord* newRecord = nullptr;
+			Require(before->Resolve(handles[i], oldRecord) && after->Resolve(handles[i], newRecord),
+				"both retained versions must resolve records across multiple copy-on-write pages");
+			Require(oldRecord->m_worldMatrix[3].x == float(i) &&
+				oldRecord->m_mobility == EMobilityType::Dynamic &&
+				newRecord->m_worldMatrix[3].x == float(i + 1000u),
+				"batch publication must preserve the old transform and mobility");
+		}
+		const auto replay = scene->PrepareFlight(0u, after);
+		Require(replay->m_appliedRevision == after->m_sceneRevision, "a retained flight must replay the complete batch");
+
+		updates.Clear();
+		auto stale = handles[0];
+		++stale.m_generation;
+		updates.Add({ stale, MakeRecord(999u, EMobilityType::Static), ToMask(ESceneChangeBit::Transform) });
+		updates.Add({ stale, {}, ToMask(ESceneChangeBit::None) });
+		updates.Add({ handles[1], {}, ToMask(ESceneChangeBit::None) });
+		const auto unchangedRevision = scene->GetRevision();
+		Require(scene->UpdateInstances(updates) == 1u && scene->GetRevision() == unchangedRevision,
+			"stale generations must be skipped and live no-ops must not replace records or append journal entries");
+		Require(scene->PublishVersion() == after, "a no-op batch must reuse the published version");
+		updates.Clear();
+		Require(scene->UpdateInstances(updates) == 0u, "an empty batch must be a no-op");
+	}
+
 	void TestCopyOnWritePageSharing()
 	{
 		auto scene = RHIScenePtr::Make();
@@ -505,6 +557,7 @@ int main()
 	try
 	{
 		TestGenerationalHandlesAndImmutableVersions();
+		TestBatchUpdatesPreserveVersionsAndFlightReplay();
 		TestCopyOnWritePageSharing();
 		TestRenderedMotionHistoryReleasesOldScenePages();
 		TestTwoAndThreeFlightRevisionReplay();


### PR DESCRIPTION
## Summary

Night City's 16,384 moving cars spent about 40 ms in mesh ECS, then the renderer built main/depth packets before spending another 23 ms constructing shadows on Render. Parallelize scene publication and overlap shadow packet preparation with the other passes. On the same full-GI camera sequence, mesh ECS decreases from 40.36 to 18.58 ms median and frame cadence improves from 13.20 to 18.54 FPS.

## Linked Issue

User-requested performance follow-up to #206, based on its merged main revision `e7070d27`.

## Implementation Notes

- Scan components and prepare lightweight transform records in 512-component Sailor Tasks batches. Commit records under one scene lock per batch; registration, removal, owner timestamps and journal mutation remain on the world thread.
- Publish immutable spatial indices with one independently owned partition per Worker. Join all writers before publication and retain older render views. Landscape uses the same spatial-index adapter; octree map capacity is independent of world-space extent.
- Move shadow packet construction into frame-graph Prepare on RHI. Finalize each shadow view on the general Worker pool while the coordinator builds subsequent views. Join all finalizers before cache publication/completion tokens and before Render records commands. Serialize shared shadow material/arena/texture caches across cameras.
- Run RenderScene preparation on the eight-Worker pool. Depth preparation and shadow material/arena construction remain on RHI because cold shader loads can synchronously wait for Worker jobs. GPU command recording and uploads remain in Process.
- Keep the previous-frame acquisition dependency, immutable snapshot and saved LOD choices, material metadata checks, submission cutoff and retained material generations/bindings. Transparent depth ordering and rendering quality are unchanged.
- Add focused Tracy scopes for shadow construction/finalization, snapshot clearing, scene-version release and cache return.

## Performance

Windows MSVC Release with Tracy, Ryzen 7 5800H / RTX 3060 Laptop; 16,384 dynamic cars, 229 city instances. Byte-identical settings: 1024x576, factor 1, MSAA 4, two 2048 shadow cascades, distance 600. Settings SHA-256: `fe2cb4ed0c9d3ca80b9481b65e2a9397440b905d1668b53ab2fd8432fcc84eb7`.

Full GI uses the same first 15 seconds of camera movement after 4,356 probes reach refinement 1.0 and reflections reach 64 spp:

| Metric | Before this PR | Final |
| --- | ---: | ---: |
| Mesh ECS median | 40.36 ms | 18.58 ms |
| Spatial rebuild median | 11.32 ms | 3.37 ms |
| Scene publication median | 13.42 ms | 4.68 ms |
| CPU world-frame work median | 50.13 ms | 28.62 ms |
| Frame cadence | 13.20 FPS | 18.54 FPS |

Isolating the renderer scheduling commit against the already-parallel ECS baseline gives **13.64 -> 18.54 FPS (+35.9%)** with full GI and **16.02 -> 19.67 FPS (+22.8%)** over the matched first 20 seconds with GI disabled. Full-GI Render Frame CPU mean drops from 34.60 to 11.64 ms; the elapsed preparation window grows from 28.43 to 32.72 ms because it now includes shadows. Total renderer interval decreases from 73.39 to 53.95 ms.

Shadow work has been overlapped, not eliminated: new shadow Prepare averages 31.00 ms including Worker waits; shadow Process now only records commands. Worker contention increases mesh ECS median from the intermediate 16.60 to 18.58 ms. New scopes identify another 4.82 ms in releasing submitted scene versions. Further main/depth range splitting, descriptor deduplication and reclamation work remain outside this implementation.

Final full-GI readiness: 282.80 seconds; 20 seconds of motion captured; engine/capture exit 0 and lit screenshot inspected. Local artifacts: `build/batch-contract-tests/parallel-render-{first,lighting}/`, including settings, trace, screenshot, CSV comparisons and `render-analysis/`. Earlier baselines are `camera-lod-{final,lighting}/` and `parallel-scene-{final,lighting}/`.

## Tests

- [x] Windows MSVC Release engine and DemoSailor build with Tracy.
- [x] 87 native checks: 26 GPU-culling, 38 ECS lifecycle, 13 scene-virtualization scenarios, 10 bounds.
- [x] Batch publication/flight replay, stale handles and no-ops, registration holes/shared owners, retained old spatial views, eight concurrent spatial writers versus brute-force visibility.
- [x] Three in-flight submissions concurrently build and finalize main/depth/shadow-style packets while the world publishes 32 later material generations; verify sorted payloads and saved descriptor bindings after capture release.
- [x] DirectionalShadow, PointShadow, SpotShadow, GpuOcclusionCulling and DynamicMaterials exit 0 with TestPassed events. Eight GPU occlusion scenarios pass; four visual captures inspected.
- [x] Controlled and full-GI Night City A/B captures; no descriptor-binding errors; git diff --check.
- [ ] macOS build/runtime validation.

## Agent Workflow

Implementation and implementer validation complete. Hand off with `needs-tech-review` / `agent-tech-lead`; independent QA and human-review readiness follow Tech Review. CI for the final pushed head is still pending.

## Risk

Medium: shared Windows/macOS CPU scheduling, scene lifetime and cache ownership changes. Each spatial partition and shadow packet has one writer; frame submission dependencies and material retention remain intact. Performance depends on scene distribution and contention with gameplay Workers. Visual-test success is not a pixel-level shadow regression oracle; macOS validation remains outstanding.
