### PR TITLE
Fix material SSBO indices after allocation alignment

### DIFF
--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -2093,10 +2093,8 @@ RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDes
 				binding->m_vulkan.m_valueBinding = TManagedMemoryPtr<VulkanBufferMemoryPtr, VulkanBufferAllocator>::Make(storageAllocator->Allocate(paddedSize, paddedSize), storageAllocator);
 				binding->m_vulkan.m_descriptorSetLayout = vkLayoutBinding;
 
-				check(((*(binding->m_vulkan.m_valueBinding->Get())).m_offset % paddedSize) == 0);
-				uint32_t instanceIndex = (uint32_t)((*(binding->m_vulkan.m_valueBinding->Get())).m_offset / paddedSize);
-
-				binding->m_vulkan.m_storageInstanceIndex = instanceIndex;
+				binding->m_vulkan.m_storageInstanceIndex = SsboLayout::ResolveInstanceIndex(
+					binding->m_vulkan.m_valueBinding->Get(), paddedSize);
 				binding->SetLayout(layoutBinding);
 			}
 		}
@@ -2374,10 +2372,8 @@ RHI::RHIShaderBindingSetPtr VulkanGraphicsDriver::CloneMaterialShaderBindings(
 				TManagedMemoryPtr<VulkanBufferMemoryPtr, VulkanBufferAllocator>::Make(
 					allocator->Allocate(paddedSize, paddedSize),
 					allocator);
-			const auto& allocation = targetBinding->m_vulkan.m_valueBinding->Get();
-			check((allocation.m_offset % paddedSize) == 0u);
-			targetBinding->m_vulkan.m_storageInstanceIndex =
-				static_cast<uint32_t>(allocation.m_offset / paddedSize);
+			targetBinding->m_vulkan.m_storageInstanceIndex = SsboLayout::ResolveInstanceIndex(
+				targetBinding->m_vulkan.m_valueBinding->Get(), paddedSize);
 		}
 	}
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -34,6 +34,16 @@ namespace Sailor::GraphicsDriver::Vulkan
 				elementSize :
 				elementSize + SsboElementAlignment - remainder;
 		}
+
+		inline uint32_t ResolveInstanceIndex(
+			const Memory::TMemoryPtr<Memory::VulkanBufferMemoryPtr>& allocation,
+			size_t stride)
+		{
+			// The buffer address includes padding before the allocated record.
+			const auto bufferRange = *allocation;
+			check(bufferRange.m_offset % stride == 0u);
+			return static_cast<uint32_t>(bufferRange.m_offset / stride);
+		}
 	}
 
 	class VulkanGraphicsDriver : public RHI::IGraphicsDriver, public RHI::IGraphicsDriverCommands

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -10,6 +10,7 @@
 #include "RHI/Lighting.h"
 #include "RHI/GpuCulling.h"
 #include "FrameGraph/DepthPrepassNode.h"
+#include "GraphicsDriver/Vulkan/VulkanShaderModule.h"
 #include "Workspace/WorkspaceCacheContract.h"
 
 #include <array>
@@ -28,6 +29,12 @@
 namespace
 {
 	using namespace Sailor;
+
+	class ShaderLayoutProbe final : public GraphicsDriver::Vulkan::VulkanShaderStage
+	{
+	public:
+		using VulkanShaderStage::ReflectDescriptorSetBindings;
+	};
 
 	class FixedShaderSourceStateProvider final : public IShaderSourceStateProvider
 	{
@@ -290,6 +297,70 @@ namespace
 				std::to_string(set) + ", binding " + std::to_string(binding) +
 				": reflected=" + std::to_string(reflectedStride) +
 				", expected=" + std::to_string(expectedStride));
+	}
+
+	void RequireGltfMaterialLayout(const RHI::ShaderByteCode& byteCode,
+		const RHI::ShaderByteCode& reflectionByteCode,
+		uint32_t payloadSize, uint32_t stride)
+	{
+		RequireSpirvStorageBufferArrayStride(byteCode, 3u, 0u, stride);
+		ShaderLayoutProbe shader;
+		shader.ReflectDescriptorSetBindings(reflectionByteCode);
+		const RHI::ShaderLayoutBinding* material = nullptr;
+		for (const auto& set : shader.GetBindings())
+		{
+			for (const auto& binding : set)
+			{
+				if (binding.m_set == 3u && binding.m_binding == 0u)
+					material = &binding;
+			}
+		}
+		Require(material && material->m_size == payloadSize && material->m_paddedSize == stride,
+			"material upload size and array stride must retain internal and trailing std430 padding");
+		ShaderLayoutProbe optimizedShader;
+		optimizedShader.ReflectDescriptorSetBindings(byteCode);
+		for (const auto& set : optimizedShader.GetBindings())
+		{
+			for (const auto& binding : set)
+			{
+				if (binding.m_set != 3u || binding.m_binding != 0u)
+					continue;
+				Require(binding.m_members.Num() == material->m_members.Num(),
+					"optimized and reflection shaders must retain the same material fields");
+				for (size_t i = 0u; i < binding.m_members.Num(); ++i)
+				{
+					Require(binding.m_members[i].m_absoluteOffset == material->m_members[i].m_absoluteOffset &&
+						binding.m_members[i].m_size == material->m_members[i].m_size,
+						"CPU reflection and optimized GPU shader must agree on every material field offset and size");
+				}
+			}
+		}
+		auto binding = RHI::RHIShaderBindingPtr::Make();
+		binding->SetLayout(*material);
+		auto requireMember = [&](const char* name, uint32_t offset, uint32_t size)
+		{
+			RHI::ShaderLayoutBindingMember member;
+			Require(binding->FindVariableInUniformBuffer(name, member) &&
+				member.m_absoluteOffset == offset && member.m_size == size,
+				std::string("CPU material packing must preserve the reflected offset and size of ") + name);
+		};
+		requireMember("baseColorFactor", 0u, 16u);
+		requireMember("sheenRoughnessFactor", 84u, 4u);
+		requireMember("sheenColorFactor", 96u, 16u);
+		requireMember("sheenRoughnessSampler", 128u, 4u);
+		if (payloadSize == 176u)
+		{
+			requireMember("transmissionFactor", 132u, 4u);
+			requireMember("thicknessFactor", 140u, 4u);
+			requireMember("attenuationDistance", 144u, 4u);
+			requireMember("indexOfRefraction", 148u, 4u);
+			requireMember("thicknessSampler", 152u, 4u);
+			requireMember("attenuationColor", 160u, 16u);
+		}
+		else if (payloadSize == 136u)
+		{
+			requireMember("indexOfRefraction", 132u, 4u);
+		}
 	}
 
 	void RequireSkyUniformLayout(const RHI::ShaderByteCode& byteCode)
@@ -1248,7 +1319,8 @@ namespace
 		auto compileRuntimeStage = [&contentRoot](
 			const char* shaderPath,
 			std::initializer_list<const char*> permutationDefines,
-			RHI::EShaderStage stage)
+			RHI::EShaderStage stage,
+			bool bIsDebug = false)
 			-> RHI::ShaderByteCode
 		{
 			const std::filesystem::path sourcePath = contentRoot / shaderPath;
@@ -1298,7 +1370,7 @@ namespace
 					source,
 					stage,
 					byteCode,
-					false),
+					bIsDebug),
 				std::string("runtime shader stage should compile: ") + shaderPath +
 					" " + stageDefine);
 			Require(!byteCode.IsEmpty(),
@@ -1308,12 +1380,14 @@ namespace
 		};
 		auto compileRuntimeFragment = [&compileRuntimeStage](
 			const char* shaderPath,
-			std::initializer_list<const char*> permutationDefines)
+			std::initializer_list<const char*> permutationDefines,
+			bool bIsDebug = false)
 		{
 			return compileRuntimeStage(
 				shaderPath,
 				permutationDefines,
-				RHI::EShaderStage::Fragment);
+				RHI::EShaderStage::Fragment,
+				bIsDebug);
 		};
 		auto compileRuntimeVertex = [&compileRuntimeStage](
 			const char* shaderPath,
@@ -1354,6 +1428,9 @@ namespace
 		{
 			const RHI::ShaderByteCode byteCode =
 				compileRuntimeFragment(shaderPaths[shaderIndex], {});
+			if (shaderIndex == 1u)
+				RequireGltfMaterialLayout(byteCode,
+					compileRuntimeFragment(shaderPaths[shaderIndex], {}, true), 132u, 144u);
 			if (shaderIndex < 3u)
 			{
 				RequireLocalReflectionUniformLayout(byteCode);
@@ -1427,11 +1504,17 @@ namespace
 			1u,
 			19u);
 		RequireLocalReflectionUniformLayout(materialExtensionsByteCode);
+		RequireGltfMaterialLayout(materialExtensionsByteCode, compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader", { "CLEAR_COAT", "SHEEN", "TRANSMISSION" }, true), 176u, 176u);
+		RequireGltfMaterialLayout(compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader", { "TRANSMISSION", "MOTIONS" }), compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader", { "TRANSMISSION", "MOTIONS" }, true), 176u, 176u);
 		RequireSpirvCombinedImageSamplerBinding(materialExtensionsByteCode, 1u, 21u);
 		RequireSpirvCombinedImageSamplerBinding(materialExtensionsByteCode, 1u, 22u);
-		compileRuntimeFragment(
+		RequireGltfMaterialLayout(compileRuntimeFragment(
 			"Shaders/Standard_glTF.shader",
-			{ "MATERIAL_IOR" });
+			{ "MATERIAL_IOR" }), compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader", { "MATERIAL_IOR" }, true), 136u, 144u);
 		compileRuntimeVertex(
 			"Shaders/Standard_glTF.shader",
 			{ "SKINNING", "TRANSMISSION" });

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -143,6 +143,32 @@ namespace
 			"non-array storage blocks must fall back to their reflected padded size");
 	}
 
+	void TestMaterialInstanceIndexIncludesAllocationPadding()
+	{
+		using Allocation = Memory::TMemoryPtr<Memory::VulkanBufferMemoryPtr>;
+		const Memory::VulkanBufferMemoryPtr storage({}, 0u, 65536u);
+		const Allocation glass(12960u, 64u, 176u, storage, 0u);
+		Require(SsboLayout::ResolveInstanceIndex(glass, 176u) == 74u,
+			"glass at byte 13024 must use material index 74, not the preceding record");
+
+		for (const size_t stride : { 16u, 144u, 176u, 192u })
+		{
+			for (size_t offset = 0u; offset < 2048u; ++offset)
+			{
+				uint32_t padding = 0u;
+				Require(Memory::Align(stride, stride,
+					Memory::Shift(storage, offset), storage.m_size - offset, padding),
+					"the material record must fit after alignment");
+				const Allocation allocation(offset, padding, stride, storage, 0u);
+				const uint32_t index = SsboLayout::ResolveInstanceIndex(allocation, stride);
+				Require(static_cast<size_t>(index) * stride == (*allocation).m_offset,
+					"shader indexing and buffer uploads must address the same aligned record");
+				Require(index == (offset + stride - 1u) / stride,
+					"mixed material strides must round the byte offset up, including already aligned records");
+			}
+		}
+	}
+
 	void TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot()
 	{
 		using DescriptorCacheKey =
@@ -393,6 +419,8 @@ int main()
 			TestStagingAllocationIdentityKeepsEveryRange },
 		{ "SsboElementAlignmentPreservesStd430Stride",
 			TestSsboElementAlignmentPreservesStd430Stride },
+		{ "MaterialInstanceIndexIncludesAllocationPadding",
+			TestMaterialInstanceIndexIncludesAllocationPadding },
 		{ "DescriptorCacheKeyKeepsItsCompatibilitySnapshot",
 			TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot },
 		{ "ConcurrentMapConstFindDoesNotExposeEndIterator",


### PR DESCRIPTION
## Summary

Fix incorrect material reads from the shared SSBO after a material's shader bindings are cloned.

The allocator already aligns each record to its reflected array stride. The clone path calculated `materialInstance` from the allocation's raw offset and omitted its alignment padding, while uploads used the resolved buffer offset. For example, a record at byte 13024 with stride 176 was addressed as index 73 instead of 74. This made NightCity car glass read another material's values, including zero transmission.

## Implementation notes

- Use one aligned, buffer-relative index calculation for material creation and cloning.
- Keep the existing reflected std430 array stride and field packing unchanged.
- Cover aligned and padded allocations across four strides and 8192 offsets, plus the reproduced glass allocation.
- Compile and reflect opaque, IOR, transmission/extensions, and transmission + MOTIONS variants. Verify internal/trailing padding and every field's offset/size against the optimized GPU shader.

## Scope

Exactly four engine/test files. No DemoSailor settings, assets, generated metadata, diagnostic shaders, temporary instrumentation, schema changes, or unrelated local edits are included. This PR is independent of #207.

## Validation / QA report

- macOS Release engine and paired DemoSailor build: passed.
- `ctest --test-dir build-mac-vcpkg -C Release -R '^(VulkanDescriptorCacheTests|ShaderCacheArtifactTests)$' --output-on-failure`: 2/2 passed.
- DemoSailor Release tests with the active Ultra profile: 12/12 passed.
- Native NightCity shot 2 at 17 seconds, High, GI fully refined (3872 probes), local reflections at 64 spp: the cabin is visible through the windshield and side windows with the original shader/material.
- Native ForestRiver launch verified on High and Ultra; GI ready, with Ultra using 4x MSAA and four shadow cascades out to 600 m.
- `git diff --check`: passed.
- The four files in this isolated branch are byte-identical to the locally validated files. The working scene and its unrelated local changes were left untouched.
- Windows validation is delegated to this PR's CI.

## Agent workflow

- [x] Implementation summary and local QA results are recorded above.
- [ ] Technical review requested; independent approval is pending.
- [ ] CI and final human review pending.

No separate issue was filed for this directly requested fix. Do not auto-merge.

## Risk

Low: the change only corrects material instance indices during binding creation/cloning. GPU layouts, shader calculations, and render passes are unchanged.
