### PR TITLE
Cache render material metadata and defer scene version release

### DIFF
--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -6,6 +6,7 @@
 #include "RHI/Texture.h"
 #include "RHI/Types.h"
 #include "RHI/Batch.hpp"
+#include "RHI/MaterialPreparationCache.h"
 #include "RHI/VertexDescription.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
@@ -87,6 +88,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 			}
 			const uint64_t materialSubmissionId =
 				sceneViewSnapshot.m_submissionContext->GetSubmissionId();
+			RHIMaterialPreparationCache preparedMaterials(materialSubmissionId);
 
 			auto submissionResources = sceneViewSnapshot.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
 				this,
@@ -281,8 +283,9 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						{
 							depthMaterial = sourceMaterial;
 						}
-						const bool bReady = depthMaterial && depthMaterial->GetVertexShader() &&
-							depthMaterial->GetFragmentShader() && depthMaterial->GetRenderState().IsEnabledZWrite();
+						const bool bReady = depthMaterial &&
+							preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders &&
+							depthMaterial->GetRenderState().IsEnabledZWrite();
 						if (!bReady)
 						{
 							if (bRequiredCustomDepth)
@@ -296,7 +299,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 							return;
 						}
 
-						RHIBatch batch(depthMaterial, mesh, materialSubmissionId);
+						RHIBatch batch = preparedMaterials.MakeBatch(depthMaterial, mesh);
 						PerInstanceData data;
 						data.model = model;
 						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
@@ -304,12 +307,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 							bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
 						if (bRequiredCustomDepth)
 						{
-							const auto bindings = batch.GetMaterialBindings();
-							if (bindings && bindings->GetShaderBindings().ContainsKey("material"))
-							{
-								const auto binding = bindings->GetShaderBindings()["material"];
-								data.materialInstance = binding ? binding->GetStorageInstanceIndex() : 0u;
-							}
+							data.materialInstance = preparedMaterials.Get(depthMaterial).m_materialInstance;
 						}
 						else if (bMaskedQueue)
 						{
@@ -581,8 +579,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 					}
 
 					const bool bIsDepthMaterialReady = depthMaterial &&
-						depthMaterial->GetVertexShader() &&
-						depthMaterial->GetFragmentShader() &&
+						preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders &&
 						depthMaterial->GetRenderState().IsEnabledZWrite();
 
 					if (!bIsDepthMaterialReady)
@@ -597,7 +594,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						}
 						continue;
 					}
-					RHIBatch batch(depthMaterial, mesh, materialSubmissionId);
+					RHIBatch batch = preparedMaterials.MakeBatch(depthMaterial, mesh);
 
 					const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(i);
 					DepthPrepassNode::PerInstanceData data;
@@ -607,13 +604,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 
 					if (bRequiredCustomDepth)
 					{
-						RHIShaderBindingPtr shaderBinding;
-						const auto materialBindings = batch.GetMaterialBindings();
-						if (materialBindings && materialBindings->GetShaderBindings().ContainsKey("material"))
-						{
-							shaderBinding = materialBindings->GetShaderBindings()["material"];
-						}
-						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
+						data.materialInstance = preparedMaterials.Get(depthMaterial).m_materialInstance;
 					}
 					else if (bMaskedQueue)
 					{
@@ -787,8 +778,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						}
 
 						const bool bIsDepthMaterialReady = depthMaterial &&
-							depthMaterial->GetVertexShader() &&
-							depthMaterial->GetFragmentShader() &&
+							preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders &&
 							depthMaterial->GetRenderState().IsEnabledZWrite();
 						if (!bIsDepthMaterialReady)
 						{
@@ -803,20 +793,11 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 							continue;
 						}
 
-						RHIBatch batchTemplate(
-							depthMaterial,
-							sourceMesh,
-							materialSubmissionId);
+						RHIBatch batchTemplate = preparedMaterials.MakeBatch(depthMaterial, sourceMesh);
 						uint32_t materialInstance = 0u;
 						if (bRequiredCustomDepth)
 						{
-							const auto materialBindings = batchTemplate.GetMaterialBindings();
-							if (materialBindings && materialBindings->GetShaderBindings().ContainsKey("material"))
-							{
-								const auto shaderBinding = materialBindings->GetShaderBindings()["material"];
-								materialInstance = shaderBinding.IsValid() ?
-									shaderBinding->GetStorageInstanceIndex() : 0u;
-							}
+							materialInstance = preparedMaterials.Get(depthMaterial).m_materialInstance;
 						}
 						else if (bMaskedQueue && meshIndex < group.m_baseColorSamplers.Num())
 						{

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -1,4 +1,5 @@
 #include "RenderSceneNode.h"
+#include "RHI/MaterialPreparationCache.h"
 #include "RHI/SceneView.h"
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
@@ -416,6 +417,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 			}
 			const uint64_t materialSubmissionId =
 				sceneViewSnapshot.m_submissionContext->GetSubmissionId();
+			RHIMaterialPreparationCache preparedMaterials(materialSubmissionId);
 
 			auto submissionResources = sceneViewSnapshot.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
 				this,
@@ -594,32 +596,27 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 								{
 									continue;
 								}
-								if (!mesh || !material->GetVertexShader() || !material->GetFragmentShader())
+								if (!mesh || !preparedMaterials.Get(material).m_bHasGraphicsShaders)
 								{
 									bRangeComplete = false;
 									continue;
 								}
 
-								RHIBatch batch(material, mesh, materialSubmissionId);
-								const auto materialBindings = batch.GetMaterialBindings();
+								RHIBatch batch = preparedMaterials.MakeBatch(material, mesh);
+								const auto* materialBindings = batch.GetMaterialBindingsRaw();
 								if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
 								{
 									bRangeComplete = false;
 									continue;
 								}
 
-								RHIShaderBindingPtr materialBinding;
-								if (materialBindings->GetShaderBindings().ContainsKey("material"))
-								{
-									materialBinding = materialBindings->GetShaderBindings()["material"];
-								}
+								const uint32_t materialInstance = preparedMaterials.Get(material).m_materialInstance;
 								PerInstanceData data;
 								data.model = proxy.ResolveMeshWorldMatrix(meshIndex);
 								data.motion = ResolveMeshMotion(sceneViewSnapshot, proxy, meshIndex);
 								data.motion.m_state.z = material->GetRenderState().GetBlendMode() != EBlendMode::None;
 								data.skeletonOffset = proxy.GetSkeletonOffset();
-								data.materialInstance =
-									materialBinding ? materialBinding->GetStorageInstanceIndex() : 0u;
+								data.materialInstance = materialInstance;
 								data.bIsCulled = 0u;
 								data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 								data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
@@ -646,25 +643,21 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 									{
 										continue;
 									}
-									if (!mesh || !material->GetVertexShader() || !material->GetFragmentShader())
+									if (!mesh || !preparedMaterials.Get(material).m_bHasGraphicsShaders)
 									{
 										bRangeComplete = false;
 										continue;
 									}
 
-									RHIBatch batch(material, mesh, materialSubmissionId);
-									const auto materialBindings = batch.GetMaterialBindings();
+									RHIBatch batch = preparedMaterials.MakeBatch(material, mesh);
+									const auto* materialBindings = batch.GetMaterialBindingsRaw();
 									if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
 									{
 										bRangeComplete = false;
 										continue;
 									}
 
-									RHIShaderBindingPtr materialBinding;
-									if (materialBindings->GetShaderBindings().ContainsKey("material"))
-									{
-										materialBinding = materialBindings->GetShaderBindings()["material"];
-									}
+									const uint32_t materialInstance = preparedMaterials.Get(material).m_materialInstance;
 									for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
 										++instanceIndex)
 									{
@@ -674,8 +667,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 										data.motion = ResolveMeshMotion(sceneViewSnapshot, proxy, meshIndex, &group, instanceIndex);
 										data.motion.m_state.z = material->GetRenderState().GetBlendMode() != EBlendMode::None;
 										data.skeletonOffset = proxy.GetSkeletonOffset();
-										data.materialInstance =
-											materialBinding ? materialBinding->GetStorageInstanceIndex() : 0u;
+										data.materialInstance = materialInstance;
 										data.bIsCulled = 0u;
 										data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 										data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
@@ -745,8 +737,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 					const bool bRelevantMaterial = material &&
 						material->GetRenderState().GetTag() == QueueTagHash;
 					const bool bHasMaterialShaders = mesh && bRelevantMaterial &&
-						material->GetVertexShader() &&
-						material->GetFragmentShader();
+						preparedMaterials.Get(material).m_bHasGraphicsShaders;
 
 					if (!bHasMaterialShaders)
 					{
@@ -756,8 +747,8 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						}
 						continue;
 					}
-					RHI::RHIBatch batch(material, mesh, materialSubmissionId);
-					const auto materialBindings = batch.GetMaterialBindings();
+					RHIBatch batch = preparedMaterials.MakeBatch(material, mesh);
+					const auto* materialBindings = batch.GetMaterialBindingsRaw();
 					if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
 					{
 						bPayloadComplete[payloadIndex] = false;
@@ -766,11 +757,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 
 					if (bRelevantMaterial)
 					{
-						RHIShaderBindingPtr shaderBinding;
-						if (materialBindings->GetShaderBindings().ContainsKey("material"))
-						{
-							shaderBinding = materialBindings->GetShaderBindings()["material"];
-						}
+						const uint32_t materialInstance = preparedMaterials.Get(material).m_materialInstance;
 
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
@@ -816,8 +803,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						data.motion = ResolveMeshMotion(sceneViewSnapshot, proxy, i);
 						data.motion.m_state.z = material->GetRenderState().GetBlendMode() != EBlendMode::None;
 						data.skeletonOffset = proxy.GetSkeletonOffset();
-						data.materialInstance = shaderBinding.IsValid() ?
-							shaderBinding->GetStorageInstanceIndex() : 0u;
+						data.materialInstance = materialInstance;
 						data.bIsCulled = 0u;
 						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
@@ -869,8 +855,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						const bool bRelevantMaterial = material &&
 							material->GetRenderState().GetTag() == QueueTagHash;
 						const bool bHasMaterialShaders = sourceMesh && bRelevantMaterial &&
-							material->GetVertexShader() &&
-							material->GetFragmentShader();
+							preparedMaterials.Get(material).m_bHasGraphicsShaders;
 						if (!bHasMaterialShaders)
 						{
 							if (bRelevantMaterial)
@@ -880,22 +865,15 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 							continue;
 						}
 
-						RHI::RHIBatch batchTemplate(
-							material,
-							sourceMesh,
-							materialSubmissionId);
-						const auto materialBindings = batchTemplate.GetMaterialBindings();
+						RHIBatch batchTemplate = preparedMaterials.MakeBatch(material, sourceMesh);
+						const auto* materialBindings = batchTemplate.GetMaterialBindingsRaw();
 						if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
 						{
 							bPayloadComplete[payloadIndex] = false;
 							continue;
 						}
 
-						RHIShaderBindingPtr shaderBinding;
-						if (materialBindings->GetShaderBindings().ContainsKey("material"))
-						{
-							shaderBinding = materialBindings->GetShaderBindings()["material"];
-						}
+						const uint32_t materialInstance = preparedMaterials.Get(material).m_materialInstance;
 
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
@@ -966,8 +944,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 							data.motion = ResolveMeshMotion(sceneViewSnapshot, proxy, meshIndex, &group, instanceIndex);
 							data.motion.m_state.z = material->GetRenderState().GetBlendMode() != EBlendMode::None;
 							data.skeletonOffset = proxy.GetSkeletonOffset();
-							data.materialInstance = shaderBinding.IsValid() ?
-								shaderBinding->GetStorageInstanceIndex() : 0u;
+							data.materialInstance = materialInstance;
 							data.bIsCulled = 0u;
 							data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 							data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -1,6 +1,7 @@
 #include "ShadowPrepassNode.h"
 #include "Core/StringHash.h"
 #include "RHI/Batch.hpp"
+#include "RHI/MaterialPreparationCache.h"
 #include "RHI/SceneView.h"
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
@@ -183,6 +184,9 @@ Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGrap
 		{
 			SAILOR_PROFILE_SCOPE("Prepare shadow packets");
 			const uint64_t materialSubmissionId = sceneView.m_submissionContext->GetSubmissionId();
+			// These are immutable pass materials; custom derivatives already retain
+			// the source generation resolved below with materialSubmissionId.
+			RHIMaterialPreparationCache preparedMaterials(0ull);
 			auto submissionResources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
 				this, sceneView.m_cameraIndex, 0u);
 			m_syncSharedResources.Lock();
@@ -444,8 +448,7 @@ Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGrap
 												depthMaterial = customShadowMaterial;
 											}
 										}
-										if (!depthMaterial || !depthMaterial->GetVertexShader() ||
-											!depthMaterial->GetFragmentShader())
+										if (!depthMaterial || !preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders)
 										{
 											bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
 											return;
@@ -453,13 +456,12 @@ Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGrap
 
 										// Shadow materials are immutable derivatives of the exact source
 										// version resolved for this submission.
-										RHIBatch batch(depthMaterial, mesh);
-										const auto materialBindings = batch.GetMaterialBindings();
+										RHIBatch batch = preparedMaterials.MakeBatch(depthMaterial, mesh);
 										PerInstanceData data;
 										data.model = model;
 										data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 										data.materialInstance =
-											materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+											preparedMaterials.Get(depthMaterial).m_materialInstance;
 										data.skeletonOffset =
 											bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
 										data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
@@ -621,21 +623,20 @@ Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGrap
 						}
 
 						const bool bIsDepthMaterialReady =
-							depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
+							depthMaterial && preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders;
 
 						if (!bIsDepthMaterialReady)
 						{
 							bShadowPayloadComplete[passIndex][payloadIndex] = false;
 							continue;
 						}
-						RHIBatch batch(depthMaterial, mesh);
+						RHIBatch batch = preparedMaterials.MakeBatch(depthMaterial, mesh);
 
 						ShadowPrepassNode::PerInstanceData data;
 						data.model = meshWorldMatrix;
 						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-						const auto materialBindings = batch.GetMaterialBindings();
 						data.materialInstance =
-							materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+							preparedMaterials.Get(depthMaterial).m_materialInstance;
 						data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
 						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
 						data.baseColorAlpha = shadowMesh.m_baseColorFactor.a;
@@ -734,17 +735,16 @@ Tasks::TaskPtr<void, void> ShadowPrepassNode::Prepare(RHIFrameGraphPtr frameGrap
 							}
 
 							const bool bIsDepthMaterialReady =
-								depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
+								depthMaterial && preparedMaterials.Get(depthMaterial).m_bHasGraphicsShaders;
 							if (!bIsDepthMaterialReady)
 							{
 								bShadowPayloadComplete[passIndex][payloadIndex] = false;
 								continue;
 							}
 
-							RHIBatch batchTemplate(depthMaterial, sourceMesh);
-							const auto materialBindings = batchTemplate.GetMaterialBindings();
+							RHIBatch batchTemplate = preparedMaterials.MakeBatch(depthMaterial, sourceMesh);
 							const uint32_t materialInstance =
-								materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+								preparedMaterials.Get(depthMaterial).m_materialInstance;
 							if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
 							{
 								uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -59,6 +59,11 @@ namespace Sailor::RHI
 			return m_materialVersion ? m_materialVersion->GetBindings() : RHIShaderBindingSetPtr{};
 		}
 
+		const RHIShaderBindingSet* GetMaterialBindingsRaw() const
+		{
+			return m_materialVersion ? m_materialVersion->GetBindingsRaw() : nullptr;
+		}
+
 		bool operator==(const RHIBatch& rhs) const
 		{
 			// Shared meshes in a traffic/vegetation run already have identical
@@ -69,8 +74,8 @@ namespace Sailor::RHI
 			{
 				return true;
 			}
-			const auto bindings = GetMaterialBindings();
-			const auto rhsBindings = rhs.GetMaterialBindings();
+			const auto* bindings = GetMaterialBindingsRaw();
+			const auto* rhsBindings = rhs.GetMaterialBindingsRaw();
 			if (!m_material || !rhs.m_material || !m_mesh || !rhs.m_mesh ||
 				!m_mesh->m_vertexBuffer || !rhs.m_mesh->m_vertexBuffer ||
 				!m_mesh->m_indexBuffer || !rhs.m_mesh->m_indexBuffer ||
@@ -97,7 +102,7 @@ namespace Sailor::RHI
 
 		size_t GetHash() const
 		{
-			const auto bindings = GetMaterialBindings();
+			const auto* bindings = GetMaterialBindingsRaw();
 			size_t hash = bindings ? bindings->GetCompatibilityHashCode() : 0u;
 
 			HashCombine(hash, m_materialVersion);

--- a/Runtime/RHI/Material.h
+++ b/Runtime/RHI/Material.h
@@ -75,6 +75,8 @@ namespace Sailor::RHI
 		uint64_t GetVersionId() const { return m_versionId; }
 		uint64_t GetPublicationRevision() const { return m_publicationRevision; }
 		RHIShaderBindingSetPtr GetBindings() const { return m_bindings; }
+		// A borrowed view is valid while this immutable version remains retained.
+		const RHIShaderBindingSet* GetBindingsRaw() const { return m_bindings.GetRawPtr(); }
 
 	private:
 		uint64_t m_versionId = 0ull;

--- a/Runtime/RHI/MaterialPreparationCache.h
+++ b/Runtime/RHI/MaterialPreparationCache.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "RHI/Batch.hpp"
+
+namespace Sailor::RHI
+{
+	// One preparation task owns this cache. Every lookup uses the same submission
+	// cutoff; later world publications cannot change already captured draw metadata.
+	class RHIMaterialPreparationCache
+	{
+	public:
+		struct Entry
+		{
+			RHIMaterialPtr m_material{};
+			RHIMaterialVersionPtr m_version{};
+			uint32_t m_materialInstance = 0u;
+			bool m_bHasGraphicsShaders = false;
+		};
+
+		explicit RHIMaterialPreparationCache(uint64_t submissionId) :
+			m_submissionId(submissionId)
+		{}
+
+		const Entry& Get(const RHIMaterialPtr& material)
+		{
+			const Entry* existing = nullptr;
+			if (m_entries.Find(material.GetRawPtr(), existing))
+			{
+				return *existing;
+			}
+			SAILOR_PROFILE_SCOPE("Capture material draw metadata");
+			auto& entry = m_entries[material.GetRawPtr()];
+			entry.m_material = material;
+			if (material)
+			{
+				entry.m_bHasGraphicsShaders = material->GetVertexShader() && material->GetFragmentShader();
+				entry.m_version = material->GetVersionForSubmission(m_submissionId);
+				const auto* bindings = entry.m_version ? entry.m_version->GetBindingsRaw() : nullptr;
+				if (bindings)
+				{
+					const RHIShaderBindingPtr* binding = nullptr;
+					if (bindings->GetShaderBindings().Find("material", binding) && *binding)
+					{
+						entry.m_materialInstance = (*binding)->GetStorageInstanceIndex();
+					}
+				}
+			}
+			return entry;
+		}
+
+		RHIBatch MakeBatch(const RHIMaterialPtr& material, const RHIMeshPtr& mesh)
+		{
+			const auto& entry = Get(material);
+			RHIBatch result;
+			result.m_material = entry.m_material;
+			result.m_materialVersion = entry.m_version;
+			result.m_mesh = mesh;
+			return result;
+		}
+
+	private:
+		uint64_t m_submissionId = 0ull;
+		TMap<const RHIMaterial*, Entry> m_entries{};
+	};
+}

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -169,7 +169,7 @@ Renderer::~Renderer()
 	{
 		if (App::GetSubmodule<Tasks::Scheduler>())
 		{
-			Renderer::GetDriver()->WaitIdle();
+			WaitIdle();
 		}
 	}
 
@@ -179,6 +179,7 @@ Renderer::~Renderer()
 	// reference can be released from a late shader-module destructor after the
 	// instance has already been destroyed (MoltenVK crashes in that ordering).
 	m_previousRenderFrame.Clear();
+	m_previousSceneVersionRelease.Clear();
 	m_frameGraph.Clear();
 	m_cachedSceneViews.Clear();
 	m_submissionContexts.Clear();
@@ -370,19 +371,14 @@ void Renderer::BeginConditionalDestroy()
 	if (!m_bIsInitialized)
 	{
 		m_previousRenderFrame.Clear();
+		m_previousSceneVersionRelease.Clear();
 		m_frameGraph.Clear();
 		m_cachedSceneViews.Clear();
 		m_submissionContexts.Clear();
 		return;
 	}
 
-	if (m_previousRenderFrame.IsValid())
-	{
-		m_previousRenderFrame->Wait();
-		m_previousRenderFrame.Clear();
-	}
-
-	Renderer::GetDriver()->WaitIdle();
+	WaitIdle();
 
 	m_frameGraph.Clear();
 	m_cachedSceneViews.Clear();
@@ -918,7 +914,36 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 					{
 						SAILOR_PROFILE_SCOPE("Clear submitted scene view");
+						// Bound deferred ownership to one older frame. Normally its release
+						// overlaps the next frame's setup and is already complete here.
+						if (m_previousSceneVersionRelease)
+						{
+							SAILOR_PROFILE_SCOPE("Wait previous scene version release");
+							m_previousSceneVersionRelease->Wait();
+							m_previousSceneVersionRelease.Clear();
+						}
+						if (!rhiSceneView->m_sceneVersions.IsEmpty() ||
+							!rhiSceneView->m_virtualSceneVersions.IsEmpty() ||
+							rhiSceneView->m_retainedSceneVersions)
+						{
+							m_previousSceneVersionRelease = Tasks::CreateTask("Release submitted scene versions",
+								[spatial = std::move(rhiSceneView->m_sceneVersions),
+									versions = std::move(rhiSceneView->m_virtualSceneVersions),
+									retained = std::move(rhiSceneView->m_retainedSceneVersions)]() mutable
+								{
+									SAILOR_PROFILE_SCOPE("Reclaim submitted scene versions");
+									spatial.Clear();
+									versions.Clear();
+									retained.Clear();
+								}, EThreadType::Worker);
+						}
+						// Drop snapshot references before the worker runs, so the last
+						// reference (and expensive root destruction) stays with the task.
 						rhiSceneView->Clear();
+						if (m_previousSceneVersionRelease)
+						{
+							m_previousSceneVersionRelease->Run();
+						}
 					}
 
 					{
@@ -962,6 +987,11 @@ void Renderer::WaitIdle()
 	{
 		m_previousRenderFrame->Wait();
 		m_previousRenderFrame.Clear();
+	}
+	if (m_previousSceneVersionRelease)
+	{
+		m_previousSceneVersionRelease->Wait();
+		m_previousSceneVersionRelease.Clear();
 	}
 
 	if (m_driverInstance)

--- a/Runtime/RHI/Renderer.h
+++ b/Runtime/RHI/Renderer.h
@@ -97,6 +97,7 @@ namespace Sailor::RHI
 		TConcurrentMap<WorldPtr, TList<TPair<RHISceneViewPtr,bool>>, 4, ERehashPolicy::Never> m_cachedSceneViews{};
 			TUniquePtr<IGraphicsDriver> m_driverInstance{};
 			Tasks::ITaskPtr m_previousRenderFrame{};
+			Tasks::ITaskPtr m_previousSceneVersionRelease{};
 			TVector<RHIRenderSubmissionContextPtr> m_submissionContexts{};
 			std::atomic<uint64_t> m_nextSubmissionId = 1ull;
 			uint64_t m_frameGraphResourceGeneration = 0ull;

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -21,6 +21,7 @@
 #include "Raytracing/MaterialUtils.h"
 #include "RHI/Buffer.h"
 #include "RHI/Material.h"
+#include "RHI/MaterialPreparationCache.h"
 #include "RHI/Mesh.h"
 #include "RHI/Texture.h"
 #include "RHI/VertexDescription.h"
@@ -537,6 +538,8 @@ namespace
 		}
 		std::array<RHI::RHIMeshPtr, 2> meshes{
 			RHI::RHIMeshPtr::Make(), RHI::RHIMeshPtr::Make() };
+		std::array<RHI::RHIShaderBindingSetPtr, 2> textures{
+			RHI::RHIShaderBindingSetPtr::Make(), RHI::RHIShaderBindingSetPtr::Make() };
 		RHI::TPackedDrawPacket<Instance> packet;
 		constexpr uint32_t count = 4097u;
 		for (uint32_t flight = 0u; flight < 2u; ++flight)
@@ -550,7 +553,10 @@ namespace
 			{
 				const uint32_t id = (index * 37u) % count;
 				const auto& mesh = meshes[(id / materials.size()) % meshes.size()];
-				packet.Add(RHI::RHIBatch(materials[id % materials.size()], mesh), mesh, {id}, id);
+				RHI::RHIBatch batch(materials[id % materials.size()], mesh);
+				batch.m_textureBindings = textures[(id / (materials.size() * meshes.size())) % textures.size()];
+				const uint64_t stableKey = (uint64_t(id) << 40u) | (count - id);
+				packet.Add(std::move(batch), mesh, {id}, stableKey);
 			}
 			packet.Finalize(false);
 			std::array<bool, count> seen{};
@@ -566,13 +572,43 @@ namespace
 					seen[id] = true;
 					++visited;
 					Require(group.m_batch.m_materialVersion == materials[id % materials.size()]->GetVersion() &&
-						group.m_mesh == meshes[(id / materials.size()) % meshes.size()],
-						"sorting and packet reuse must preserve each instance's mesh and material generation");
+						group.m_mesh == meshes[(id / materials.size()) % meshes.size()] &&
+						group.m_batch.m_textureBindings == textures[(id / (materials.size() * meshes.size())) % textures.size()],
+						"sorting and packet reuse must preserve each instance's mesh, textures and material generation");
 					Require(offset == 0u || previousId < id, "instances sharing a draw must retain stable key order");
 					previousId = id;
 				}
 			}
 			Require(visited == count, "all mixed-material instances must reach the draw packet");
+		}
+	}
+
+	void TestPackedDrawEqualKeysPreserveBindingOrder()
+	{
+		std::array<RHI::RHIMaterialPtr, 2u> materials;
+		for (auto& material : materials)
+		{
+			material = RHI::RHIMaterialPtr::Make(
+				RHI::RenderState{}, RHI::RHIShaderPtr{}, RHI::RHIShaderPtr{});
+		}
+		materials[0]->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+		const auto version = materials[0]->GetVersion();
+		RHI::TPackedDrawPacket<uint32_t> packet;
+		for (uint32_t index = 0u; index < 32u; ++index)
+		{
+			RHI::RHIBatch batch(materials[index % materials.size()], {});
+			batch.m_materialVersion = version;
+			packet.Add(std::move(batch), {}, index, 17ull);
+		}
+		packet.Finalize(false);
+		Require(packet.GetGroups().Num() == 32u,
+			"equal sort keys must not merge distinct binding owners across intervening draws");
+		for (uint32_t index = 0u; index < 32u; ++index)
+		{
+			Require(packet.GetPayload(EMobilityType::Dynamic).m_instances[index] == index &&
+				packet.GetGroups()[index].m_batch.m_material == materials[index % materials.size()] &&
+				packet.GetGroups()[index].m_batch.m_materialVersion == version,
+				"equal sort keys must preserve insertion order and each draw's retained binding owner");
 		}
 	}
 
@@ -915,6 +951,8 @@ namespace
 		for (size_t frame = 0u; frame < versions.size(); ++frame)
 		{
 			bindings[frame] = RHI::RHIShaderBindingSetPtr::Make();
+			bindings[frame]->GetOrAddShaderBinding("material")->m_vulkan.m_storageInstanceIndex =
+				static_cast<uint32_t>(100u + frame);
 			material->SetBindings(bindings[frame]);
 			versions[frame] = material->GetVersion();
 			RHI::RHIMaterial::BeginSubmissionVersionCapture(400ull + frame);
@@ -926,6 +964,7 @@ namespace
 		{
 			renderWorkers.emplace_back([&, frame]()
 				{
+					RHI::RHIMaterialPreparationCache preparedMaterials(400ull + frame);
 					for (size_t nextFrame = 0u; nextFrame < 32u; ++nextFrame)
 					{
 						sync.arrive_and_wait();
@@ -937,7 +976,7 @@ namespace
 							packet.Reset();
 							for (uint32_t index = 0u; index < NumInstances; ++index)
 							{
-								packet.Add(RHI::RHIBatch(material, {}, 400ull + frame), {},
+								packet.Add(preparedMaterials.MakeBatch(material, {}), {},
 									NumInstances - index, NumInstances - index);
 							}
 							packet.Finalize(false);
@@ -947,7 +986,9 @@ namespace
 								continue;
 							}
 							const auto& batch = packet.GetGroups()[0].m_batch;
-							if (batch.m_materialVersion != versions[frame] || batch.GetMaterialBindings() != bindings[frame])
+							if (batch.m_materialVersion != versions[frame] || batch.GetMaterialBindings() != bindings[frame] ||
+								preparedMaterials.Get(material).m_materialInstance != 100u + frame ||
+								batch.GetMaterialBindingsRaw() != bindings[frame].GetRawPtr())
 							{
 								valid.store(false);
 							}
@@ -1620,6 +1661,7 @@ int main()
 		{ "PackedDrawMixedMaterialSort", TestPackedDrawMixedMaterialSort },
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
 		{ "MaterialVersionsSurviveConcurrentWorldUpdates", TestMaterialVersionsSurviveConcurrentWorldUpdates },
+		{ "PackedDrawEqualKeysPreserveBindingOrder", TestPackedDrawEqualKeysPreserveBindingOrder },
 		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
 		{ "ParallelSpatialIndexVisibility", TestParallelSpatialIndexVisibility },
 		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },


### PR DESCRIPTION
## Summary

Main, depth and shadow packet preparation repeatedly acquires the same material version and looks up its bindings for thousands of instances. The Render thread also destroys retained CPU scene versions after submission. Cache material draw metadata within each preparation task and release completed scene versions on a Worker.

## Linked Issue

User-requested performance follow-up to #207. Based on `main` at `092a1206`, including the material SSBO alignment fix from #208.

## Implementation Notes

- Add a preparation-local cache of the retained material/version, graphics-shader availability and material SSBO index. Main/depth lookups use the submission cutoff. Shadow derivatives already retain the source generation selected for that submission.
- Every produced batch still owns its material version. Borrowed binding reads are used while that version remains retained, avoiding temporary reference-count updates during hashing, comparison and preparation. GPU descriptor recording retains owning references.
- Move submitted scene-version containers into one Worker task after dropping snapshot references. Wait for the previous release before scheduling another; drain the task in renderer idle/destruction paths. Existing frame acquisition dependencies and GPU ownership remain intact.
- Extend packet tests for textures, full-width stable keys and equal-key insertion order. Exercise three simultaneous submissions while the world publishes 32 later material generations, checking retained bindings and cached SSBO indices.

## Tests

Local Windows Release build and all 27 batch/GPU-culling checks now pass on the exact PR head `6b358d1b`, including the #208 base. MSVC/clang-cl CI was still running when these local measurements completed.

- [x] Windows MSVC Release engine and DemoSailor build with Tracy disabled.
- [x] All 27 GPU-culling/batch contract checks passed against that DLL.
- [x] Night City with 16,384 cars: full GI reached 4,356/4,356 probes and reflections reached 64 spp; moving scene inspected, no descriptor-binding errors in the log.
- [x] `python update_deps.py` after fetching main: successful, dependencies already current.
- [x] `git diff --check`.
- [x] Controlled PresentMon A/B of #208 against the exact PR head, both Release without Tracy, with identical settings and two 70-second camera loops per variant.
- [ ] Final-patch shadow/material world suite, in-process world switching and repeated shutdown under load.
- [ ] macOS build/runtime validation.

The demo's four-GI-worker setting, FPS cap and local Tracy build option are local configuration. They are excluded from this PR.

## Performance

PresentMon 1.5.2, Ryzen 7 5800H / RTX 3060 Laptop, MSVC Release without Tracy; same High settings, 1024x576, MSAA 2, 4 GI workers, cap 500. Each variant completed two 70-second automatic camera loops after 4,356 probes reached refinement 1.0 and reflections reached 64 spp.

| Metric | Base #208 | PR #209 |
| --- | ---: | ---: |
| Present cadence | 19.50 FPS | 20.42 FPS |
| Mean frame interval | 51.29 ms | 48.98 ms |
| p95 frame interval | 67.64 ms | 67.36 ms |
| p99 frame interval | 71.95 ms | 72.23 ms |
| First / second loop | 19.50 / 19.50 FPS | 20.33 / 20.51 FPS |

Average FPS improves by **4.73%**. Long-frame percentiles are essentially unchanged. Both captures have zero dropped presents, the same presentation mode and zero descriptor-binding errors; both processes shut down normally. One launch per variant (base first) limits conclusions about separate-launch and thermal-order variance. Camera boundaries are observed from flushed world-thread logs and can differ by a small number of queued frames.

Settings SHA-256: `3d82fb1c0dd447c44e3d76f389c4c4f59536f26fd7ce777d8026a2acc2e92a0b`. The invalid local GI publication limit of 400/s was replaced with 4/s for both runs (supported maximum 60/s). The original settings and raw CSVs/markers/hashes are archived locally in `build/batch-contract-tests/pr209-ab/`.

## Agent Workflow

The PR was merged by the maintainer while the A/B was running. The review/QA checklist below records the outstanding agent validation; no independent approval is inferred from the merge.

- [x] Implementation Summary is included above; handoff comment accompanies this draft.
- [ ] Tech Review: requested (`needs-tech-review` / `agent-tech-lead`).
- [ ] Independent QA follows Tech Review; pending checks are listed above.
- [ ] Ready for human review only after Tech Review and QA approval.

## Risk

Medium. This changes shared Windows/macOS resource lifetime and CPU scheduling. Review the borrowed binding lifetimes, submission-version retention and ordering of deferred release versus renderer/world shutdown. The measured average FPS improvement is modest (+4.73%); p95/p99 frame intervals are essentially unchanged. Separate-launch/thermal-order variance and macOS remain unmeasured.
