### PR TITLE
Fix Windows window sizing tests on small CI desktops

### DIFF
--- a/Tests/WindowsWindowSizingTests.cpp
+++ b/Tests/WindowsWindowSizingTests.cpp
@@ -73,13 +73,13 @@ int main()
 		// DefWindowProc limits overlapped windows to the desktop tracking size.
 		// A CI desktop can be smaller than the requested 1280x800 client area.
 		const SIZE maximum = GetMaximumClientExtent(window.GetHWND());
-		const int largeWidth = std::min(1280L, maximum.cx);
-		const int largeHeight = std::min(800L, maximum.cy);
+		const int largeWidth = std::min<LONG>(1280, maximum.cx);
+		const int largeHeight = std::min<LONG>(800, maximum.cy);
 		window.ChangeWindowSize(largeWidth, largeHeight);
 		window.Show(false);
 		CheckClientExtent(window, largeWidth, largeHeight);
-		const int smallWidth = std::min(853L, maximum.cx);
-		const int smallHeight = std::min(479L, maximum.cy);
+		const int smallWidth = std::min<LONG>(853, maximum.cx);
+		const int smallHeight = std::min<LONG>(479, maximum.cy);
 		window.ChangeWindowSize(smallWidth, smallHeight);
 		window.Show(false);
 		CheckClientExtent(window, smallWidth, smallHeight);

--- a/Tests/WindowsWindowSizingTests.cpp
+++ b/Tests/WindowsWindowSizingTests.cpp
@@ -1,5 +1,6 @@
 #include "Platform/Win32/Window.h"
 #include <windows.h>
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -18,13 +19,34 @@ namespace
 	{
 		RECT client{};
 		Require(GetClientRect(window.GetHWND(), &client), "client rectangle must be readable");
+		std::cout << "[INFO] Expected client " << width << 'x' << height
+			<< ", native " << client.right - client.left << 'x' << client.bottom - client.top
+			<< ", renderer " << window.GetWidth() << 'x' << window.GetHeight()
+			<< ", DPI " << GetDpiForWindow(window.GetHWND()) << '\n';
 		Require(client.right - client.left == width && client.bottom - client.top == height,
-			"the physical client area must match the requested render dimensions");
+			"the physical client area must match the expected render dimensions");
 		Require(window.GetWidth() == width && window.GetHeight() == height,
 			"the renderer must receive client dimensions without DPI scaling or window borders");
 		window.RecalculateWindowSize();
 		Require(window.GetWidth() == width && window.GetHeight() == height,
 			"recalculating the window size must preserve client dimensions");
+	}
+
+	SIZE GetMaximumClientExtent(HWND window)
+	{
+		const UINT dpi = GetDpiForWindow(window);
+		RECT frame{};
+		Require(AdjustWindowRectExForDpi(&frame,
+			static_cast<DWORD>(GetWindowLongPtr(window, GWL_STYLE)), FALSE,
+			static_cast<DWORD>(GetWindowLongPtr(window, GWL_EXSTYLE)), dpi),
+			"the native window frame must have valid physical dimensions");
+		const SIZE maximum{
+			GetSystemMetricsForDpi(SM_CXMAXTRACK, dpi) - (frame.right - frame.left),
+			GetSystemMetricsForDpi(SM_CYMAXTRACK, dpi) - (frame.bottom - frame.top)
+		};
+		Require(maximum.cx > 0 && maximum.cy > 0,
+			"the desktop must allow a non-empty client area");
+		return maximum;
 	}
 }
 
@@ -48,13 +70,25 @@ int main()
 		CheckClientExtent(window, 640, 400);
 		std::cout << "[PASS] Startup client extent at DPI " << GetDpiForWindow(window.GetHWND()) << '\n';
 
-		window.ChangeWindowSize(1280, 800);
+		// DefWindowProc limits overlapped windows to the desktop tracking size.
+		// A CI desktop can be smaller than the requested 1280x800 client area.
+		const SIZE maximum = GetMaximumClientExtent(window.GetHWND());
+		const int largeWidth = std::min(1280L, maximum.cx);
+		const int largeHeight = std::min(800L, maximum.cy);
+		window.ChangeWindowSize(largeWidth, largeHeight);
 		window.Show(false);
-		CheckClientExtent(window, 1280, 800);
-		window.ChangeWindowSize(853, 479);
+		CheckClientExtent(window, largeWidth, largeHeight);
+		const int smallWidth = std::min(853L, maximum.cx);
+		const int smallHeight = std::min(479L, maximum.cy);
+		window.ChangeWindowSize(smallWidth, smallHeight);
 		window.Show(false);
-		CheckClientExtent(window, 853, 479);
+		CheckClientExtent(window, smallWidth, smallHeight);
 		std::cout << "[PASS] Resizing preserves exact physical client dimensions\n";
+
+		window.ChangeWindowSize(maximum.cx + 128, maximum.cy + 128);
+		window.Show(false);
+		CheckClientExtent(window, maximum.cx, maximum.cy);
+		std::cout << "[PASS] Renderer dimensions follow OS-limited window sizes\n";
 
 		RECT suggested{ 100, 100, 740, 500 };
 		const UINT dpi = GetDpiForWindow(window.GetHWND());


### PR DESCRIPTION
## Summary

Fix the shared Windows CI failure in `WindowsWindowSizingTests` seen in Engine Build runs [34145631092](https://github.com/aantropov/sailor/actions/runs/34145631092) and [34141711264](https://github.com/aantropov/sailor/actions/runs/34141711264), on both MSVC and clang-cl. The engine compiles and the other 33 native tests pass in both runs.

## Implementation Summary

- Keep exact physical-pixel assertions for startup, resize, recalculation, and the DPI-change suggested rectangle.
- Bound the normal resize cases by the desktop maximum tracking size, subtracting the DPI-aware non-client frame. The previous test unconditionally expected a 1280x800 client even on smaller desktops.
- Add an explicitly oversized resize and require both the native client area and renderer dimensions to match the OS-limited extent.
- Log expected/native/renderer extents and DPI so failures include actual measurements.
- Use explicit `std::min<LONG>` calls to avoid Win32 `min` macro expansion.

Windows validates overlapped window sizes through [WM_WINDOWPOSCHANGING](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-windowposchanging); the maximum tracking dimensions are exposed by [MINMAXINFO/system metrics](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-minmaxinfo).

## Scope and Risk

Low risk: only `Tests/WindowsWindowSizingTests.cpp` changes. No runtime behavior, CI exclusions, dependencies, assets, demo settings, or schema versions change. No tests are skipped or disabled.

## Validation

- `git diff --check`: passed.
- Head: `c07bc5798f4965ac6c143bafd29c66cf35b1997e`.
- [Engine Build 34203249562](https://github.com/aantropov/sailor/actions/runs/34203249562): **passed on both MSVC and clang-cl**.
  - 34/34 native tests, including `WindowsWindowSizingTests`.
  - 808/808 editor contract tests.
  - Source workspace configure/build/DLL validation.
  - Two-workspace phase 1 and fresh-process phase 2.
- [Build Editor 34203249586](https://github.com/aantropov/sailor/actions/runs/34203249586): **passed**, including the MCP bridge.
- Local macOS editor contracts: 808/808 passed after initializing the pinned vcpkg submodule and running `python3 update_deps.py`. Native Win32 behavior was validated on the Windows CI runners, not on macOS.

## Agent Workflow

- [x] Implementation Summary posted above.
- [x] Tech Review requested (`needs-tech-review`).
- [x] Current-head CI validation results and QA report posted.
- [ ] Ready for human review only after Tech Review and QA approval.

No linked issue; user-requested CI repair. Do not merge automatically.
